### PR TITLE
Fix Windows Demo Issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,17 +82,19 @@ score. In the demo we have a preprocessed graph and a test dataset with Uber rid
 
 Launch Docker in the background and from inside the root directory run:
 
+Linux/Mac:
 ```zsh 
 cd kuwala/scripts && sh initialize_core_components.sh && sh run_cli.sh
 ```
-
-***Note***: Some people on Windows experience installation issues with the CLI. If that is the case for you please open 
-an issue. In the meantime you can run the pipelines individually.
+and for Windows:
+```PS
+cd kuwala/scripts/windows && sh initialize_core_components.sh && sh run_cli.sh
+```
 
 #### Run the data pipelines yourself
 
-To run the pipelines yourself, build the components first from inside the `kuwala/scripts` directory by executing the 
-`initialize_all_components.sh` script and the starting the CLI by running the `run_cli.sh` script.
+To run the pipelines yourself, build the components first from inside the `kuwala/scripts` directory (or if the computer uses Windows, go to `kuwala/scripts/windows`) by executing the 
+`initialize_all_components.sh` script and the starting the CLI by running the `run_cli.sh` script. .
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Linux/Mac:
 ```zsh 
 cd kuwala/scripts && sh initialize_core_components.sh && sh run_cli.sh
 ```
-and for Windows:
+and for Windows (Please use PowerShell or any Docker integrated terminal):
 ```PS
 cd kuwala/scripts/windows && sh initialize_core_components.sh && sh run_cli.sh
 ```

--- a/kuwala/scripts/windows/build_all_containers.sh
+++ b/kuwala/scripts/windows/build_all_containers.sh
@@ -1,0 +1,3 @@
+cd ..
+cd ..
+docker-compose build google-poi-api google-poi-pipeline neo4j-importer osm-parquetizer osm-poi population-density

--- a/kuwala/scripts/windows/build_cli.sh
+++ b/kuwala/scripts/windows/build_cli.sh
@@ -1,0 +1,8 @@
+cd ..
+cd ..
+cd ..
+pip3 install virtualenv
+virtualenv -p python3 venv
+source ./venv/bin/activate
+pip install -r kuwala/core/cli/requirements.txt
+pip install -e .

--- a/kuwala/scripts/windows/build_jupyter_notebook.sh
+++ b/kuwala/scripts/windows/build_jupyter_notebook.sh
@@ -1,0 +1,3 @@
+cd ..
+cd ..
+docker-compose build jupyter

--- a/kuwala/scripts/windows/build_neo4j.sh
+++ b/kuwala/scripts/windows/build_neo4j.sh
@@ -1,0 +1,3 @@
+cd ..
+cd ..
+docker-compose build neo4j

--- a/kuwala/scripts/windows/create_zip_archive.sh
+++ b/kuwala/scripts/windows/create_zip_archive.sh
@@ -1,0 +1,4 @@
+cd ..
+cd ..
+cd ..
+git archive --format=zip HEAD -o kuwala.zip

--- a/kuwala/scripts/windows/initialize_all_components.sh
+++ b/kuwala/scripts/windows/initialize_all_components.sh
@@ -1,0 +1,5 @@
+sh initialize_git_submodules.sh
+sh build_neo4j.sh
+sh build_cli.sh
+sh build_jupyter_notebook.sh
+sh build_all_containers.sh

--- a/kuwala/scripts/windows/initialize_core_components.sh
+++ b/kuwala/scripts/windows/initialize_core_components.sh
@@ -1,0 +1,3 @@
+sh build_neo4j.sh
+sh build_cli.sh
+sh build_jupyter_notebook.sh

--- a/kuwala/scripts/windows/initialize_git_submodules.sh
+++ b/kuwala/scripts/windows/initialize_git_submodules.sh
@@ -1,0 +1,4 @@
+cd ..
+cd ..
+cd ..
+git submodule update --init --recursive

--- a/kuwala/scripts/windows/run_cli.sh
+++ b/kuwala/scripts/windows/run_cli.sh
@@ -1,0 +1,6 @@
+cd ..
+cd ..
+cd ..
+source ./venv/bin/activate
+cd kuwala/core/cli
+python3 src/main.py

--- a/kuwala/scripts/windows/run_jupyter_notebook.sh
+++ b/kuwala/scripts/windows/run_jupyter_notebook.sh
@@ -1,0 +1,3 @@
+cd ..
+cd ..
+docker-compose run --service-ports jupyter

--- a/kuwala/scripts/windows/stop_all_containers.sh
+++ b/kuwala/scripts/windows/stop_all_containers.sh
@@ -1,0 +1,4 @@
+reset
+docker stop $(docker ps -a -q)
+docker-compose down
+docker-compose rm -f


### PR DESCRIPTION
According to [this](https://github.com/kuwala-io/kuwala/issues/62#issuecomment-982660277) comment. I tried to fix the issue related to Windows by:

1. Created a `windows` folder inside `scripts` folder
2. Rewrote and checked each `.sh` script and save them inside `windows` folder
3. Add a little of  Windows installation related guide in the readme

So next time, if we want to run this from a Windows machine, just go to `windows` folder and all automation should run smoothly
Thank you!