### PR TITLE
Fix Windows Demo and Installation Issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ tmp
 env
 !.env.local
 __pycache__
+
+
+kuwala/scripts/windows/

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ cd kuwala/scripts && sh initialize_core_components.sh && sh run_cli.sh
 ```
 and for Windows (Please use PowerShell or any Docker integrated terminal):
 ```PS
-cd kuwala/scripts && sh initialize_windows.sh && sh initialize_core_components.sh && sh run_cli.sh
+cd kuwala/scripts && sh initialize_windows.sh && cd windows && sh initialize_core_components.sh && sh run_cli.sh
 ```
 
 #### Run the data pipelines yourself

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ cd kuwala/scripts && sh initialize_core_components.sh && sh run_cli.sh
 ```
 and for Windows (Please use PowerShell or any Docker integrated terminal):
 ```PS
-cd kuwala/scripts/windows && sh initialize_core_components.sh && sh run_cli.sh
+cd kuwala/scripts && sh initialize_windows.sh && sh initialize_core_components.sh && sh run_cli.sh
 ```
 
 #### Run the data pipelines yourself

--- a/kuwala/README.md
+++ b/kuwala/README.md
@@ -9,7 +9,7 @@ Installed version of *Docker* and *docker-compose*
 
 ### Pipelines
 
-If you want to build all containers for all pipelines, change your working directory to `./kuwala/scripts` and run:
+If you want to build all containers for all pipelines, change your working directory to `./kuwala/scripts` (or move to `./kuwala/scripts/`, run `initialize_windows.sh`, and change directory to `windows/` if you are running a Windows machine) and run:
 
 ```zsh
 sh initialize_all_components.sh
@@ -33,7 +33,7 @@ Now you can proceed to any of the pipelines' `README.md` and follow the steps to
 
 ### Core
 
-To initialize the CLI and Jupyter notebook run within the `./kuwala/scripts` directory:
+To initialize the CLI and Jupyter notebook run within the `./kuwala/scripts` directory (or `./kuwala/scripts/windows` ):
 
 ```zsh
 sh initialize_core_components.sh

--- a/kuwala/scripts/initialize_windows.sh
+++ b/kuwala/scripts/initialize_windows.sh
@@ -10,4 +10,3 @@ sed 's/\r$//' run_cli.sh > ./windows/run_cli.sh
 sed 's/\r$//' run_jupyter_notebook.sh > ./windows/run_jupyter_notebook.sh
 sed 's/\r$//' stop_all_containers.sh > ./windows/stop_all_containers.sh
 sed 's/\r$//' build_all_containers.sh > ./windows/build_all_containers.sh
-cd windows

--- a/kuwala/scripts/initialize_windows.sh
+++ b/kuwala/scripts/initialize_windows.sh
@@ -1,0 +1,13 @@
+mkdir windows
+sed 's/\r$//' initialize_all_components.sh > ./windows/initialize_all_components.sh
+sed 's/\r$//' build_cli.sh > ./windows/build_cli.sh
+sed 's/\r$//' build_jupyter_notebook.sh > ./windows/build_jupyter_notebook.sh
+sed 's/\r$//' build_neo4j.sh > ./windows/build_neo4j.sh
+sed 's/\r$//' create_zip_archive.sh > ./windows/create_zip_archive.sh
+sed 's/\r$//' initialize_core_components.sh > ./windows/initialize_core_components.sh
+sed 's/\r$//' initialize_git_submodules.sh > ./windows/initialize_git_submodules.sh
+sed 's/\r$//' run_cli.sh > ./windows/run_cli.sh
+sed 's/\r$//' run_jupyter_notebook.sh > ./windows/run_jupyter_notebook.sh
+sed 's/\r$//' stop_all_containers.sh > ./windows/stop_all_containers.sh
+sed 's/\r$//' build_all_containers.sh > ./windows/build_all_containers.sh
+cd windows

--- a/kuwala/scripts/windows/build_all_containers.sh
+++ b/kuwala/scripts/windows/build_all_containers.sh
@@ -1,3 +1,0 @@
-cd ..
-cd ..
-docker-compose build google-poi-api google-poi-pipeline neo4j-importer osm-parquetizer osm-poi population-density

--- a/kuwala/scripts/windows/build_cli.sh
+++ b/kuwala/scripts/windows/build_cli.sh
@@ -1,8 +1,0 @@
-cd ..
-cd ..
-cd ..
-pip3 install virtualenv
-virtualenv -p python3 venv
-source ./venv/bin/activate
-pip install -r kuwala/core/cli/requirements.txt
-pip install -e .

--- a/kuwala/scripts/windows/build_jupyter_notebook.sh
+++ b/kuwala/scripts/windows/build_jupyter_notebook.sh
@@ -1,3 +1,0 @@
-cd ..
-cd ..
-docker-compose build jupyter

--- a/kuwala/scripts/windows/build_neo4j.sh
+++ b/kuwala/scripts/windows/build_neo4j.sh
@@ -1,3 +1,0 @@
-cd ..
-cd ..
-docker-compose build neo4j

--- a/kuwala/scripts/windows/create_zip_archive.sh
+++ b/kuwala/scripts/windows/create_zip_archive.sh
@@ -1,4 +1,0 @@
-cd ..
-cd ..
-cd ..
-git archive --format=zip HEAD -o kuwala.zip

--- a/kuwala/scripts/windows/initialize_all_components.sh
+++ b/kuwala/scripts/windows/initialize_all_components.sh
@@ -1,5 +1,0 @@
-sh initialize_git_submodules.sh
-sh build_neo4j.sh
-sh build_cli.sh
-sh build_jupyter_notebook.sh
-sh build_all_containers.sh

--- a/kuwala/scripts/windows/initialize_core_components.sh
+++ b/kuwala/scripts/windows/initialize_core_components.sh
@@ -1,3 +1,0 @@
-sh build_neo4j.sh
-sh build_cli.sh
-sh build_jupyter_notebook.sh

--- a/kuwala/scripts/windows/initialize_git_submodules.sh
+++ b/kuwala/scripts/windows/initialize_git_submodules.sh
@@ -1,4 +1,0 @@
-cd ..
-cd ..
-cd ..
-git submodule update --init --recursive

--- a/kuwala/scripts/windows/run_cli.sh
+++ b/kuwala/scripts/windows/run_cli.sh
@@ -1,6 +1,0 @@
-cd ..
-cd ..
-cd ..
-source ./venv/bin/activate
-cd kuwala/core/cli
-python3 src/main.py

--- a/kuwala/scripts/windows/run_jupyter_notebook.sh
+++ b/kuwala/scripts/windows/run_jupyter_notebook.sh
@@ -1,3 +1,0 @@
-cd ..
-cd ..
-docker-compose run --service-ports jupyter

--- a/kuwala/scripts/windows/stop_all_containers.sh
+++ b/kuwala/scripts/windows/stop_all_containers.sh
@@ -1,4 +1,0 @@
-reset
-docker stop $(docker ps -a -q)
-docker-compose down
-docker-compose rm -f


### PR DESCRIPTION
According to [this](https://github.com/kuwala-io/kuwala/issues/62#issuecomment-982660277) comment. I tried to fix the issue again, but now I made this more sustainable:

1. Created a script that creates `windows` folder
2. That script will 'translate' all of shell scripts so it is runable inside windows environments
3. Add a little of  Windows installation related guide in the readme

So next time, if we want to run this from a Windows machine, we can run them from `windows` folder but if we are not using a Windows machine, we don't need to create them so it will make storage more efficient.
Thank you!