### PR TITLE
Cleaner Error Message for Incorrect Input in Google-POI

### DIFF
--- a/kuwala/pipelines/google-poi/README.md
+++ b/kuwala/pipelines/google-poi/README.md
@@ -70,7 +70,7 @@ URL: `/search`<br/>
 Request Body (**required**): Array of search strings<br/>
 
 *Example*: `localhost:3003/search`</br>
-Request Body:
+Request Body (in JSON format):
 
 ```json 
     [
@@ -89,7 +89,7 @@ URL: `/poi-information`<br/>
 Request Body (**required**): Array of encoded placeIDs<br/>
 
 *Example*: `localhost:3003/poi-information`<br>
-Request Body:
+Request Body (in JSON format):
 
 ```json 
     [
@@ -108,7 +108,7 @@ URL: `/popularity`<br/>
 Request Body (**required**): Array of encoded placeIDs<br/>
 
 *Example*: `localhost:3003/popularity`<br>
-Request Body:
+Request Body (in JSON format):
 
 ```json 
     [

--- a/kuwala/pipelines/google-poi/src/app.py
+++ b/kuwala/pipelines/google-poi/src/app.py
@@ -19,7 +19,7 @@ app.register_blueprint(poi_information)
 app.register_blueprint(popularity)
 app.register_error_handler(error=400, func=general_error)
 app.register_error_handler(error=429, func=general_error)
-app.register_error_handler(error=415, func=general_error)
+
 
 
 if __name__ == '__main__':

--- a/kuwala/pipelines/google-poi/src/app.py
+++ b/kuwala/pipelines/google-poi/src/app.py
@@ -19,6 +19,7 @@ app.register_blueprint(poi_information)
 app.register_blueprint(popularity)
 app.register_error_handler(error=400, func=general_error)
 app.register_error_handler(error=429, func=general_error)
+app.register_error_handler(error=415, func=general_error)
 
 
 if __name__ == '__main__':

--- a/kuwala/pipelines/google-poi/src/routes/poi_information.py
+++ b/kuwala/pipelines/google-poi/src/routes/poi_information.py
@@ -137,7 +137,7 @@ async def get_poi_information():
     ids = await request.get_json()
     
     if ids is None:
-        abort(415, description='Invalid request body, is the request body type a JSON?')
+        abort(400, description='Invalid request body, is the request body type a JSON?')
 
     if len(ids) > 100:
         abort(400, description='You can send at most 100 ids at once.')

--- a/kuwala/pipelines/google-poi/src/routes/poi_information.py
+++ b/kuwala/pipelines/google-poi/src/routes/poi_information.py
@@ -135,6 +135,9 @@ def parse_spending_time_data(spending_time_data):
 async def get_poi_information():
     """Retrieve POI information for an array of ids"""
     ids = await request.get_json()
+    
+    if ids is None:
+        abort(415, description='Invalid request body, is the request body type a JSON?')
 
     if len(ids) > 100:
         abort(400, description='You can send at most 100 ids at once.')

--- a/kuwala/pipelines/google-poi/src/routes/popularity.py
+++ b/kuwala/pipelines/google-poi/src/routes/popularity.py
@@ -12,6 +12,9 @@ async def get_popularities():
     """Retrieve current popularity for an array of ids"""
     ids = await request.get_json()
 
+    if ids is None:
+        abort(415, description='Invalid request body, is the request body type a JSON?')
+
     if len(ids) > 100:
         abort(400, description='You can send at most 100 ids at once.')
 

--- a/kuwala/pipelines/google-poi/src/routes/popularity.py
+++ b/kuwala/pipelines/google-poi/src/routes/popularity.py
@@ -13,7 +13,7 @@ async def get_popularities():
     ids = await request.get_json()
 
     if ids is None:
-        abort(415, description='Invalid request body, is the request body type a JSON?')
+        abort(400, description='Invalid request body, is the request body type a JSON?')
 
     if len(ids) > 100:
         abort(400, description='You can send at most 100 ids at once.')

--- a/kuwala/pipelines/google-poi/src/routes/search.py
+++ b/kuwala/pipelines/google-poi/src/routes/search.py
@@ -13,6 +13,9 @@ async def search_places():
     """Retrieve placeIDs for an array of query strings"""
     queries = await request.get_json()
 
+    if queries is None:
+        abort(415, description='Invalid request body, is the request body type a JSON?')
+
     if len(queries) > 100:
         abort(400, description='You can send at most 100 queries at once.')
 

--- a/kuwala/pipelines/google-poi/src/routes/search.py
+++ b/kuwala/pipelines/google-poi/src/routes/search.py
@@ -14,7 +14,7 @@ async def search_places():
     queries = await request.get_json()
 
     if queries is None:
-        abort(415, description='Invalid request body, is the request body type a JSON?')
+        abort(400, description='Invalid request body, is the request body type a JSON?')
 
     if len(queries) > 100:
         abort(400, description='You can send at most 100 queries at once.')


### PR DESCRIPTION
Looking up at this [Issue](https://github.com/kuwala-io/kuwala/issues/61), I think it is better to put error `415 Unsupported Media Type`  when the input body is not a JSON. I also left a message in the response body to make sure the request body is a JSON. Hence, in this pull request I purposed:

1) Detect JSON reading and add `415 Unsupported Media Type`  as an error if the JSON reading format is `None` (or not a JSON)
2) Add the error in `search, poi-information,` and `popularity` routes
3) Add error number 415 in the main file
4) Modify readme and mention to use JSON format in request body

Thank you ^^