### PR TITLE
Handle previously processed countries

### DIFF
--- a/kuwala/common/python_utils/src/FileSelector.py
+++ b/kuwala/common/python_utils/src/FileSelector.py
@@ -152,7 +152,7 @@ def get_countries_with_population_data(return_country_code=False):
             lambda d: 'population' in d['title'].lower() and 'csv' in d['file_types'],
             map(
                 lambda d: dict(id=d.get('id'), title=d.get('title'), location=d.get_location_names(),
-                               country_code=d.get_location_iso3s(), file_types=d.get_filetypes()),
+                               country_code=d.get_location_iso3s(), file_types=d.get_filetypes(), updated_date=d.get('last_modified')[:10]),
                 datasets
             )
         ), key=lambda d: d['location'][0])

--- a/kuwala/common/python_utils/src/FileSelector.py
+++ b/kuwala/common/python_utils/src/FileSelector.py
@@ -216,12 +216,12 @@ def select_demographic_groups(d: Dataset):
                 id=resource.get('id'),
                 format=resource.get('format'),
                 type=get_type(resource.get('name')),
-                date=resource.get('last_modified')
+                date=resource.get('last_modified')[:10],
             ),
             resources
         )
     ))
-    resources = list(map(lambda r: dict(id=r['id'], type=r['type']), resources))
+    resources = list(map(lambda r: dict(id=r['id'], type=r['type'], updated=r['date']), resources))
     resource_names = list(map(lambda r: r['type'], resources))
     selected_resources = questionary \
         .checkbox('Which demographic groups do you want to include?', choices=resource_names) \

--- a/kuwala/common/python_utils/src/FileSelector.py
+++ b/kuwala/common/python_utils/src/FileSelector.py
@@ -215,7 +215,8 @@ def select_demographic_groups(d: Dataset):
             lambda resource: dict(
                 id=resource.get('id'),
                 format=resource.get('format'),
-                type=get_type(resource.get('name'))
+                type=get_type(resource.get('name')),
+                date=resource.get('last_modified')
             ),
             resources
         )

--- a/kuwala/core/cli/src/InputController.py
+++ b/kuwala/core/cli/src/InputController.py
@@ -63,7 +63,7 @@ def select_region(pipelines: [str]) -> [str, str]:
         continent = file['continent']
         country = file['country']
         population_density_id = file['id']
-        population_density_update_date=file['last_modified']
+        population_density_update_date=file['updated_date']
 
 
     # TODO if both osm-poi and population density are selected, check if population data is available for the selected

--- a/kuwala/core/cli/src/InputController.py
+++ b/kuwala/core/cli/src/InputController.py
@@ -50,6 +50,7 @@ def select_region(pipelines: [str]) -> [str, str]:
     country_region = None
     population_density_id = None
     osm_url = None
+    update_date= None
 
     if 'osm-poi' in pipelines or 'google-poi' in pipelines:
         file = FileSelector.select_osm_file()
@@ -62,6 +63,8 @@ def select_region(pipelines: [str]) -> [str, str]:
         continent = file['continent']
         country = file['country']
         population_density_id = file['id']
+        update_date=file['last_modified']
+
 
     # TODO if both osm-poi and population density are selected, check if population data is available for the selected
     #   country
@@ -71,7 +74,8 @@ def select_region(pipelines: [str]) -> [str, str]:
         country=country,
         country_region=country_region,
         population_density_id=population_density_id,
-        osm_url=osm_url
+        osm_url=osm_url,
+        update_date=update_date
     )
 
 

--- a/kuwala/core/cli/src/InputController.py
+++ b/kuwala/core/cli/src/InputController.py
@@ -50,7 +50,7 @@ def select_region(pipelines: [str]) -> [str, str]:
     country_region = None
     population_density_id = None
     osm_url = None
-    population_density_update_date= None
+    population_density_update_date = None
 
     if 'osm-poi' in pipelines or 'google-poi' in pipelines:
         file = FileSelector.select_osm_file()
@@ -63,10 +63,9 @@ def select_region(pipelines: [str]) -> [str, str]:
         continent = file['continent']
         country = file['country']
         population_density_id = file['id']
-        population_density_update_date=file['updated_date']
+        population_density_update_date = file['updated_date']
 
-
-    # TODO if both osm-poi and population density are selected, check if population data is available for the selected
+    #  TODO if both osm-poi and population density are selected, check if population data is available for the selected
     #   country
 
     return dict(

--- a/kuwala/core/cli/src/InputController.py
+++ b/kuwala/core/cli/src/InputController.py
@@ -50,7 +50,7 @@ def select_region(pipelines: [str]) -> [str, str]:
     country_region = None
     population_density_id = None
     osm_url = None
-    update_date= None
+    population_density_update_date= None
 
     if 'osm-poi' in pipelines or 'google-poi' in pipelines:
         file = FileSelector.select_osm_file()
@@ -63,7 +63,7 @@ def select_region(pipelines: [str]) -> [str, str]:
         continent = file['continent']
         country = file['country']
         population_density_id = file['id']
-        update_date=file['last_modified']
+        population_density_update_date=file['last_modified']
 
 
     # TODO if both osm-poi and population density are selected, check if population data is available for the selected
@@ -75,7 +75,7 @@ def select_region(pipelines: [str]) -> [str, str]:
         country_region=country_region,
         population_density_id=population_density_id,
         osm_url=osm_url,
-        update_date=update_date
+        population_density_update_date=population_density_update_date
     )
 
 

--- a/kuwala/core/cli/src/PipelineOrchestrator.py
+++ b/kuwala/core/cli/src/PipelineOrchestrator.py
@@ -91,13 +91,14 @@ def run_population_density_pipeline(continent, country, demographic_groups):
     run_command([f'docker-compose run --rm population-density {continent_arg} {country_arg} {demographic_groups_arg}'])
 
 
-def run_neo4j_importer(continent, country, country_region):
+def run_neo4j_importer(continent, country, country_region, population_density_update_date):
     continent_arg = f'--continent={continent}' if continent else ''
     country_arg = f'--country={country}' if country else ''
     country_region_arg = f'--country_region={country_region}' if country_region else ''
     neo4j_process = run_command(f'docker-compose --profile core up', exit_keyword='Started.')
+    population_density_update_date_arg=f'--population_density_date={population_density_update_date}' if population_density_update_date else ''
 
-    run_command([f'docker-compose run --rm neo4j-importer {continent_arg} {country_arg} {country_region_arg}'])
+    run_command([f'docker-compose run --rm neo4j-importer {continent_arg} {country_arg} {country_region_arg} {population_density_update_date_arg} '])
     neo4j_process.terminate()
 
 
@@ -105,6 +106,8 @@ def run_pipelines(pipelines: [str], selected_region: dict):
     continent = selected_region['continent']
     country = selected_region['country']
     country_region = selected_region['country_region']
+    population_density_update_date = selected_region['population_density_update_date']
+
 
     if 'google-poi' in pipelines or 'osm-poi' in pipelines:
         run_osm_poi_pipeline(selected_region['osm_url'], continent, country, country_region)
@@ -115,5 +118,5 @@ def run_pipelines(pipelines: [str], selected_region: dict):
     if 'population-density' in pipelines:
         run_population_density_pipeline(continent, country, selected_region['demographic_groups'])
 
-    run_neo4j_importer(continent, country, country_region)
+    run_neo4j_importer(continent, country, country_region, population_density_update_date)
     run_command(['docker-compose down --remove-orphans'])

--- a/kuwala/core/cli/src/PipelineOrchestrator.py
+++ b/kuwala/core/cli/src/PipelineOrchestrator.py
@@ -83,12 +83,13 @@ def run_google_poi_pipeline(continent, country, country_region):
     scraping_api_process.terminate()
 
 
-def run_population_density_pipeline(continent, country, demographic_groups):
+def run_population_density_pipeline(continent, country, demographic_groups, population_density_update_date):
     continent_arg = f'--continent={continent}' if continent else ''
     country_arg = f'--country={country}' if country else ''
     demographic_groups_arg = f'--demographic_groups={demographic_groups}' if demographic_groups else ''
+    population_density_update_date_arg=f'--population_density_date={population_density_update_date}' if population_density_update_date else ''
 
-    run_command([f'docker-compose run --rm population-density {continent_arg} {country_arg} {demographic_groups_arg}'])
+    run_command([f'docker-compose run --rm population-density {continent_arg} {country_arg} {demographic_groups_arg} {population_density_update_date_arg}'])
 
 
 def run_neo4j_importer(continent, country, country_region):
@@ -105,6 +106,7 @@ def run_pipelines(pipelines: [str], selected_region: dict):
     continent = selected_region['continent']
     country = selected_region['country']
     country_region = selected_region['country_region']
+    updated_date=selected_region['population_density_date']
 
     if 'google-poi' in pipelines or 'osm-poi' in pipelines:
         run_osm_poi_pipeline(selected_region['osm_url'], continent, country, country_region)
@@ -113,7 +115,7 @@ def run_pipelines(pipelines: [str], selected_region: dict):
         run_google_poi_pipeline(continent, country, country_region)
 
     if 'population-density' in pipelines:
-        run_population_density_pipeline(continent, country, selected_region['demographic_groups'])
+        run_population_density_pipeline(continent, country, selected_region['demographic_groups'], updated_date)
 
     run_neo4j_importer(continent, country, country_region)
     run_command(['docker-compose down --remove-orphans'])

--- a/kuwala/core/cli/src/PipelineOrchestrator.py
+++ b/kuwala/core/cli/src/PipelineOrchestrator.py
@@ -96,9 +96,11 @@ def run_neo4j_importer(continent, country, country_region, population_density_up
     country_arg = f'--country={country}' if country else ''
     country_region_arg = f'--country_region={country_region}' if country_region else ''
     neo4j_process = run_command(f'docker-compose --profile core up', exit_keyword='Started.')
-    population_density_update_date_arg=f'--population_density_date={population_density_update_date}' if population_density_update_date else ''
+    population_density_update_date_arg = f'--population_density_date={population_density_update_date}' if \
+        population_density_update_date else ''
 
-    run_command([f'docker-compose run --rm neo4j-importer {continent_arg} {country_arg} {country_region_arg} {population_density_update_date_arg} '])
+    run_command([f'docker-compose run --rm neo4j-importer {continent_arg} {country_arg} {country_region_arg} '
+                 f'{population_density_update_date_arg} '])
     neo4j_process.terminate()
 
 
@@ -107,7 +109,6 @@ def run_pipelines(pipelines: [str], selected_region: dict):
     country = selected_region['country']
     country_region = selected_region['country_region']
     population_density_update_date = selected_region['population_density_update_date']
-
 
     if 'google-poi' in pipelines or 'osm-poi' in pipelines:
         run_osm_poi_pipeline(selected_region['osm_url'], continent, country, country_region)

--- a/kuwala/core/cli/src/PipelineOrchestrator.py
+++ b/kuwala/core/cli/src/PipelineOrchestrator.py
@@ -83,13 +83,12 @@ def run_google_poi_pipeline(continent, country, country_region):
     scraping_api_process.terminate()
 
 
-def run_population_density_pipeline(continent, country, demographic_groups, population_density_update_date):
+def run_population_density_pipeline(continent, country, demographic_groups):
     continent_arg = f'--continent={continent}' if continent else ''
     country_arg = f'--country={country}' if country else ''
     demographic_groups_arg = f'--demographic_groups={demographic_groups}' if demographic_groups else ''
-    population_density_update_date_arg=f'--population_density_date={population_density_update_date}' if population_density_update_date else ''
 
-    run_command([f'docker-compose run --rm population-density {continent_arg} {country_arg} {demographic_groups_arg} {population_density_update_date_arg}'])
+    run_command([f'docker-compose run --rm population-density {continent_arg} {country_arg} {demographic_groups_arg}'])
 
 
 def run_neo4j_importer(continent, country, country_region):
@@ -106,7 +105,6 @@ def run_pipelines(pipelines: [str], selected_region: dict):
     continent = selected_region['continent']
     country = selected_region['country']
     country_region = selected_region['country_region']
-    updated_date=selected_region['population_density_date']
 
     if 'google-poi' in pipelines or 'osm-poi' in pipelines:
         run_osm_poi_pipeline(selected_region['osm_url'], continent, country, country_region)
@@ -115,7 +113,7 @@ def run_pipelines(pipelines: [str], selected_region: dict):
         run_google_poi_pipeline(continent, country, country_region)
 
     if 'population-density' in pipelines:
-        run_population_density_pipeline(continent, country, selected_region['demographic_groups'], updated_date)
+        run_population_density_pipeline(continent, country, selected_region['demographic_groups'])
 
     run_neo4j_importer(continent, country, country_region)
     run_command(['docker-compose down --remove-orphans'])

--- a/kuwala/core/neo4j/importer/src/PopulationDensityImporter.py
+++ b/kuwala/core/neo4j/importer/src/PopulationDensityImporter.py
@@ -35,7 +35,7 @@ def import_population_density(args, limit=None):
     file_path = os.path.join(script_dir, '../tmp/kuwala/populationFiles/')
     continent = args.continent
     country = args.country
-    date = args.population-density-date 
+    date = args.population_density_date 
     date = str(date).replace('-','_')
 
     if continent is None or country is None:

--- a/kuwala/core/neo4j/importer/src/PopulationDensityImporter.py
+++ b/kuwala/core/neo4j/importer/src/PopulationDensityImporter.py
@@ -50,6 +50,9 @@ def import_population_density(args, limit=None):
         file_path += f'{continent}/{country}/{date}_result.parquet'
 
     if not os.path.exists(file_path):
+        print('file_path:')
+        print(file_path)
+        print()
         print('No population data available for import')
 
         return

--- a/kuwala/core/neo4j/importer/src/PopulationDensityImporter.py
+++ b/kuwala/core/neo4j/importer/src/PopulationDensityImporter.py
@@ -41,13 +41,13 @@ def import_population_density(args, limit=None):
     if continent is None or country is None:
         try:
             file_path = select_local_country(file_path)
-            file_path += '/result'+'_'+date+'.parquet' 
+            file_path += '/'+ date +'_result.parquet' 
         except FileNotFoundError:
             print('No population data available for import')
 
             return
     else: 
-        file_path += f'{continent}/{country}/result_{date}.parquet'
+        file_path += f'{continent}/{country}/{date}_result.parquet'
 
     if not os.path.exists(file_path):
         print('No population data available for import')

--- a/kuwala/core/neo4j/importer/src/PopulationDensityImporter.py
+++ b/kuwala/core/neo4j/importer/src/PopulationDensityImporter.py
@@ -35,7 +35,7 @@ def import_population_density(args, limit=None):
     file_path = os.path.join(script_dir, '../tmp/kuwala/populationFiles/')
     continent = args.continent
     country = args.country
-    date = args.date #added this, 
+    date = args.date 
     date = str(date).replace('-','_')
 
     if continent is None or country is None:

--- a/kuwala/core/neo4j/importer/src/PopulationDensityImporter.py
+++ b/kuwala/core/neo4j/importer/src/PopulationDensityImporter.py
@@ -41,13 +41,13 @@ def import_population_density(args, limit=None):
     if continent is None or country is None:
         try:
             file_path = select_local_country(file_path)
-            file_path += '/result'+date+'.parquet' #fix this 
+            file_path += '/result'+'_'+date+'.parquet' 
         except FileNotFoundError:
             print('No population data available for import')
 
             return
     else: 
-        file_path += f'{continent}/{country}/result_{date}.parquet' #fix this
+        file_path += f'{continent}/{country}/result_{date}.parquet'
 
     if not os.path.exists(file_path):
         print('No population data available for import')

--- a/kuwala/core/neo4j/importer/src/PopulationDensityImporter.py
+++ b/kuwala/core/neo4j/importer/src/PopulationDensityImporter.py
@@ -35,7 +35,7 @@ def import_population_density(args, limit=None):
     file_path = os.path.join(script_dir, '../tmp/kuwala/populationFiles/')
     continent = args.continent
     country = args.country
-    date = args.date 
+    date = args.population-density-date 
     date = str(date).replace('-','_')
 
     if continent is None or country is None:

--- a/kuwala/core/neo4j/importer/src/PopulationDensityImporter.py
+++ b/kuwala/core/neo4j/importer/src/PopulationDensityImporter.py
@@ -50,9 +50,6 @@ def import_population_density(args, limit=None):
         file_path += f'{continent}/{country}/{date}_result.parquet'
 
     if not os.path.exists(file_path):
-        print('file_path:')
-        print(file_path)
-        print()
         print('No population data available for import')
 
         return

--- a/kuwala/core/neo4j/importer/src/PopulationDensityImporter.py
+++ b/kuwala/core/neo4j/importer/src/PopulationDensityImporter.py
@@ -35,17 +35,19 @@ def import_population_density(args, limit=None):
     file_path = os.path.join(script_dir, '../tmp/kuwala/populationFiles/')
     continent = args.continent
     country = args.country
+    date = args.date #added this, 
+    date = str(date).replace('-','_')
 
     if continent is None or country is None:
         try:
             file_path = select_local_country(file_path)
-            file_path += '/result.parquet'
+            file_path += '/result'+date+'.parquet' #fix this 
         except FileNotFoundError:
             print('No population data available for import')
 
             return
-    else:
-        file_path += f'{continent}/{country}/result.parquet'
+    else: 
+        file_path += f'{continent}/{country}/result_{date}.parquet' #fix this
 
     if not os.path.exists(file_path):
         print('No population data available for import')

--- a/kuwala/core/neo4j/importer/src/main.py
+++ b/kuwala/core/neo4j/importer/src/main.py
@@ -7,6 +7,7 @@ import PipelineImporter as PipelineImporter
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
+    parser.add_argument('--date',help='Selected update date to process')
     parser.add_argument('--continent', help='Continent of the file')
     parser.add_argument('--country', help='Country of the file')
     parser.add_argument('--country_region', help='Country region of the file')

--- a/kuwala/core/neo4j/importer/src/main.py
+++ b/kuwala/core/neo4j/importer/src/main.py
@@ -7,10 +7,10 @@ import PipelineImporter as PipelineImporter
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
-    parser.add_argument('--population_density_date',help='Selected update date to process')
     parser.add_argument('--continent', help='Continent of the file')
     parser.add_argument('--country', help='Country of the file')
     parser.add_argument('--country_region', help='Country region of the file')
+    parser.add_argument('--population_density_date',help='Selected update date to process')
     args = parser.parse_args()
 
     PipelineImporter.start(args)

--- a/kuwala/core/neo4j/importer/src/main.py
+++ b/kuwala/core/neo4j/importer/src/main.py
@@ -7,7 +7,7 @@ import PipelineImporter as PipelineImporter
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
-    parser.add_argument('--date',help='Selected update date to process')
+    parser.add_argument('--population-density-date',help='Selected update date to process')
     parser.add_argument('--continent', help='Continent of the file')
     parser.add_argument('--country', help='Country of the file')
     parser.add_argument('--country_region', help='Country region of the file')

--- a/kuwala/core/neo4j/importer/src/main.py
+++ b/kuwala/core/neo4j/importer/src/main.py
@@ -7,7 +7,7 @@ import PipelineImporter as PipelineImporter
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
-    parser.add_argument('--population-density-date',help='Selected update date to process')
+    parser.add_argument('--population_density_date',help='Selected update date to process')
     parser.add_argument('--continent', help='Continent of the file')
     parser.add_argument('--country', help='Country of the file')
     parser.add_argument('--country_region', help='Country region of the file')

--- a/kuwala/pipelines/population-density/src/Downloader.py
+++ b/kuwala/pipelines/population-density/src/Downloader.py
@@ -2,6 +2,7 @@ import json
 import os
 import time
 import zipfile
+import glob
 from hdx.data.dataset import Dataset
 from hdx.data.resource import Resource
 from hdx.hdx_configuration import Configuration
@@ -65,12 +66,17 @@ class Downloader:
                 date=r['updated'].replace('-','_')
                 with zipfile.ZipFile(file_path_without_ext, 'r') as zip_ref:
                     zip_ref.extractall(dir_path_type)
-                file_path_with_update_date=file_path_without_ext.split('/')
+                
+                #check the extracted file name as in https://github.com/kuwala-io/kuwala/pull/67#discussion_r774395338
+                csv_file=glob.glob(dir_path_type + "*.csv", recursive = True)[0]
+                
+                #assuming there will be only one csv file as extract result
+                file_path_with_update_date=csv_file.split('/')
                 file_path_with_update_date[-1]=date+'_'+file_path_with_update_date[-1]
                 file_path_with_update_date='/'.join(file_path_with_update_date)
-                file_path_with_update_date=file_path_with_update_date.split('_csv')[0]+'.csv'
-                os.rename(file_path_without_ext.split('_csv')[0]+'.csv', file_path_with_update_date)
-                os.remove(file_path_without_ext)
+                #file_path_with_update_date=file_path_with_update_date.split('_csv')[0]+'.csv' 
+                os.rename(csv_file, file_path_with_update_date)
+                os.remove(csv_file)
 
                 end_time = time.time()
 

--- a/kuwala/pipelines/population-density/src/Downloader.py
+++ b/kuwala/pipelines/population-density/src/Downloader.py
@@ -74,7 +74,6 @@ class Downloader:
                 file_path_with_update_date=csv_file.split('/')
                 file_path_with_update_date[-1]=date+'_'+file_path_with_update_date[-1]
                 file_path_with_update_date='/'.join(file_path_with_update_date)
-                #file_path_with_update_date=file_path_with_update_date.split('_csv')[0]+'.csv' 
                 os.rename(csv_file, file_path_with_update_date)
                 os.remove(file_path_without_ext)
 

--- a/kuwala/pipelines/population-density/src/Downloader.py
+++ b/kuwala/pipelines/population-density/src/Downloader.py
@@ -65,7 +65,10 @@ class Downloader:
                 date=r['updated'].replace('-','_')
                 with zipfile.ZipFile(file_path_without_ext, 'r') as zip_ref:
                     zip_ref.extractall(dir_path_type)
-                file_path_with_update_date=file_path_without_ext.split('_csv')[0]+'_'+date+'.csv'
+                file_path_with_update_date=file_path_without_ext.split('/')
+                file_path_with_update_date[-1]=date+'_'+file_path_with_update_date[-1]
+                file_path_with_update_date='/'.join(file_path_with_update_date)
+                file_path_with_update_date=file_path_with_update_date.split('_csv')[0]+'.csv'
                 os.rename(file_path_without_ext.split('_csv')[0]+'.csv', file_path_with_update_date)
                 os.remove(file_path_without_ext)
 

--- a/kuwala/pipelines/population-density/src/Downloader.py
+++ b/kuwala/pipelines/population-density/src/Downloader.py
@@ -62,9 +62,10 @@ class Downloader:
                 file_path_without_ext = file_path.replace('.CSV', '')
                 os.rename(file_path, file_path_without_ext)
 
+                date=r['updated'].replace('-','_')
                 with zipfile.ZipFile(file_path_without_ext, 'r') as zip_ref:
                     zip_ref.extractall(dir_path_type)
-                file_path_with_update_date=file_path_without_ext.split('_csv')[0]+'_'+r['updated']+'.csv'
+                file_path_with_update_date=file_path_without_ext.split('_csv')[0]+'_'+date+'.csv'
                 os.rename(file_path_without_ext.split('_csv')[0]+'.csv', file_path_with_update_date)
                 os.remove(file_path_without_ext)
 

--- a/kuwala/pipelines/population-density/src/Downloader.py
+++ b/kuwala/pipelines/population-density/src/Downloader.py
@@ -46,12 +46,18 @@ class Downloader:
         dir_path = f'../tmp/populationFiles/{dataset["continent"]}/{dataset["country"]}/'
         dir_path = os.path.join(script_dir, dir_path)
         file_paths = list()
+        latest_update_date = None
+
         for r in selected_resources:
             dir_path_type = f'{dir_path}{r["type"]}/'
 
             file_paths.append(dict(path=dir_path_type, type=r['type']))
+            update_date = r['updated'].replace('-', '_')
 
-            date=r['updated'].replace('-','_')
+            if not latest_update_date:
+                latest_update_date = update_date
+            elif latest_update_date < update_date:
+                latest_update_date = update_date
 
             if not os.path.exists(dir_path_type):
                 print("Downloading.....")
@@ -64,17 +70,15 @@ class Downloader:
                 file_path_without_ext = file_path.replace('.CSV', '')
                 os.rename(file_path, file_path_without_ext)
 
-                
                 with zipfile.ZipFile(file_path_without_ext, 'r') as zip_ref:
                     zip_ref.extractall(dir_path_type)
-                
-                #check the extracted file name as in https://github.com/kuwala-io/kuwala/pull/67#discussion_r774395338
-                csv_file=glob.glob(dir_path_type + "*.csv", recursive = True)[0]
-                
-                #assuming there will be only one csv file as extract result
-                file_path_with_update_date=csv_file.split('/')
-                file_path_with_update_date[-1]=date+'_'+file_path_with_update_date[-1]
-                file_path_with_update_date='/'.join(file_path_with_update_date)
+
+                # check the extracted file name as in https://github.com/kuwala-io/kuwala/pull/67#discussion_r774395338
+                csv_file = glob.glob(dir_path_type + "*.csv", recursive=True)[0]
+                # assuming there will be only one csv file as extract result
+                file_path_with_update_date = csv_file.split('/')
+                file_path_with_update_date[-1] = update_date + '_' + file_path_with_update_date[-1]
+                file_path_with_update_date = '/'.join(file_path_with_update_date)
                 os.rename(csv_file, file_path_with_update_date)
                 os.remove(file_path_without_ext)
 
@@ -82,4 +86,4 @@ class Downloader:
 
                 print(f'Downloaded data for {r["type"]} in {round(end_time - start_time)} s')
 
-        return file_paths, dir_path, date
+        return file_paths, dir_path, latest_update_date

--- a/kuwala/pipelines/population-density/src/Downloader.py
+++ b/kuwala/pipelines/population-density/src/Downloader.py
@@ -20,9 +20,9 @@ class Downloader:
         else:
             dataset = select_population_file()
 
-        files, output_dir = Downloader.download_files(dataset, args)
+        files, output_dir, updated_date = Downloader.download_files(dataset, args)
 
-        return files, output_dir
+        return files, output_dir, updated_date
 
     @staticmethod
     def download_files(dataset: dict, args) -> [str]:
@@ -36,11 +36,9 @@ class Downloader:
                 dataset['continent'] = args.continent
                 dataset['country'] = args.country
                 d = Dataset.read_from_hdx(dataset['id'])
-                #update_date=Dataset.read_from_hdx(dataset['updated'])
                 selected_resources = select_demographic_groups(d)
         else:
             d = Dataset.read_from_hdx(dataset['id'])
-            #update_date=Dataset.read_from_hdx(dataset['updated'])
             selected_resources = select_demographic_groups(d)
 
         script_dir = os.path.dirname(__file__)
@@ -52,7 +50,9 @@ class Downloader:
 
             file_paths.append(dict(path=dir_path_type, type=r['type']))
 
+
             if not os.path.exists(dir_path_type):
+                print("Downloading.....")
                 r_hdx = Resource().read_from_hdx(identifier=r['id'])
                 start_time = time.time()
 
@@ -72,4 +72,4 @@ class Downloader:
 
                 print(f'Downloaded data for {r["type"]} in {round(end_time - start_time)} s')
 
-        return file_paths, dir_path
+        return file_paths, dir_path, r['updated']

--- a/kuwala/pipelines/population-density/src/Downloader.py
+++ b/kuwala/pipelines/population-density/src/Downloader.py
@@ -73,4 +73,4 @@ class Downloader:
 
                 print(f'Downloaded data for {r["type"]} in {round(end_time - start_time)} s')
 
-        return file_paths, dir_path, r['updated']
+        return file_paths, dir_path, date

--- a/kuwala/pipelines/population-density/src/Downloader.py
+++ b/kuwala/pipelines/population-density/src/Downloader.py
@@ -51,6 +51,7 @@ class Downloader:
 
             file_paths.append(dict(path=dir_path_type, type=r['type']))
 
+            date=r['updated'].replace('-','_')
 
             if not os.path.exists(dir_path_type):
                 print("Downloading.....")
@@ -63,7 +64,7 @@ class Downloader:
                 file_path_without_ext = file_path.replace('.CSV', '')
                 os.rename(file_path, file_path_without_ext)
 
-                date=r['updated'].replace('-','_')
+                
                 with zipfile.ZipFile(file_path_without_ext, 'r') as zip_ref:
                     zip_ref.extractall(dir_path_type)
                 

--- a/kuwala/pipelines/population-density/src/Downloader.py
+++ b/kuwala/pipelines/population-density/src/Downloader.py
@@ -36,16 +36,17 @@ class Downloader:
                 dataset['continent'] = args.continent
                 dataset['country'] = args.country
                 d = Dataset.read_from_hdx(dataset['id'])
+                #update_date=Dataset.read_from_hdx(dataset['updated'])
                 selected_resources = select_demographic_groups(d)
         else:
             d = Dataset.read_from_hdx(dataset['id'])
+            #update_date=Dataset.read_from_hdx(dataset['updated'])
             selected_resources = select_demographic_groups(d)
 
         script_dir = os.path.dirname(__file__)
         dir_path = f'../tmp/populationFiles/{dataset["continent"]}/{dataset["country"]}/'
         dir_path = os.path.join(script_dir, dir_path)
         file_paths = list()
-
         for r in selected_resources:
             dir_path_type = f'{dir_path}{r["type"]}/'
 
@@ -59,12 +60,12 @@ class Downloader:
 
                 url, file_path = r_hdx.download(dir_path_type)
                 file_path_without_ext = file_path.replace('.CSV', '')
-
                 os.rename(file_path, file_path_without_ext)
 
                 with zipfile.ZipFile(file_path_without_ext, 'r') as zip_ref:
                     zip_ref.extractall(dir_path_type)
-
+                file_path_with_update_date=file_path_without_ext.split('_csv')[0]+'_'+r['updated']+'.csv'
+                os.rename(file_path_without_ext.split('_csv')[0]+'.csv', file_path_with_update_date)
                 os.remove(file_path_without_ext)
 
                 end_time = time.time()

--- a/kuwala/pipelines/population-density/src/Downloader.py
+++ b/kuwala/pipelines/population-density/src/Downloader.py
@@ -76,7 +76,7 @@ class Downloader:
                 file_path_with_update_date='/'.join(file_path_with_update_date)
                 #file_path_with_update_date=file_path_with_update_date.split('_csv')[0]+'.csv' 
                 os.rename(csv_file, file_path_with_update_date)
-                os.remove(csv_file)
+                os.remove(file_path_without_ext)
 
                 end_time = time.time()
 

--- a/kuwala/pipelines/population-density/src/Processor.py
+++ b/kuwala/pipelines/population-density/src/Processor.py
@@ -46,7 +46,7 @@ class Processor:
 
         df = reduce((lambda d1, d2: d1.join(d2, ['h3Index'], 'full').repartition(number_of_partitions, 'h3Index')), dfs)
 
-        df.write.mode('overwrite').parquet(output_dir + 'result'+'_'+updated_date+'.parquet')
+        df.write.mode('overwrite').parquet(output_dir + updated_date + '_' + 'result.parquet')
 
         end_time = time.time()
 

--- a/kuwala/pipelines/population-density/src/Processor.py
+++ b/kuwala/pipelines/population-density/src/Processor.py
@@ -29,7 +29,8 @@ class Processor:
 
         for file in files:
             t = file['type']
-            df = spark.read.option('header', 'true').csv(file['path'])
+            file_versions = sorted(os.listdir(file['path']), reverse=True)
+            df = spark.read.option('header', 'true').csv(f'{file["path"]}{file_versions[0]}')
             # Column names can be written differently for different countries
             lat_column = next((c for c in df.columns if 'lat' in c.lower()), 'latitude')
             lng_column = next((c for c in df.columns if 'lon' in c.lower()), 'longitude')
@@ -46,7 +47,7 @@ class Processor:
 
         df = reduce((lambda d1, d2: d1.join(d2, ['h3Index'], 'full').repartition(number_of_partitions, 'h3Index')), dfs)
 
-        df.write.mode('overwrite').parquet(output_dir + updated_date + '_' + 'result.parquet')
+        df.write.mode('overwrite').parquet(f'{output_dir}{updated_date}_result.parquet')
 
         end_time = time.time()
 

--- a/kuwala/pipelines/population-density/src/Processor.py
+++ b/kuwala/pipelines/population-density/src/Processor.py
@@ -46,8 +46,9 @@ class Processor:
 
         df = reduce((lambda d1, d2: d1.join(d2, ['h3Index'], 'full').repartition(number_of_partitions, 'h3Index')), dfs)
 
+        date=updated_date.replace('-','_')
 
-        df.write.mode('overwrite').parquet(output_dir + 'result'+'_'+updated_date+'.parquet')
+        df.write.mode('overwrite').parquet(output_dir + 'result'+'_'+date+'.parquet')
 
         end_time = time.time()
 

--- a/kuwala/pipelines/population-density/src/Processor.py
+++ b/kuwala/pipelines/population-density/src/Processor.py
@@ -46,9 +46,7 @@ class Processor:
 
         df = reduce((lambda d1, d2: d1.join(d2, ['h3Index'], 'full').repartition(number_of_partitions, 'h3Index')), dfs)
 
-        date=updated_date.replace('-','_')
-
-        df.write.mode('overwrite').parquet(output_dir + 'result'+'_'+date+'.parquet')
+        df.write.mode('overwrite').parquet(output_dir + 'result'+'_'+updated_date+'.parquet')
 
         end_time = time.time()
 

--- a/kuwala/pipelines/population-density/src/Processor.py
+++ b/kuwala/pipelines/population-density/src/Processor.py
@@ -53,8 +53,8 @@ class Processor:
             print("parquet files already exist")
             decision=''
             while(decision!='n' or decision!='N' or decision!='y' or decision!='Y'):
-                decisionsion=input("do you want to overwrite? [Y] or skip download [N]? ")
-                if decisionsion=='n' or decisionsion=='N':
+                decision=input("do you want to overwrite? [Y] or skip download [N]? ")
+                if decision=='n' or decision=='N':
                     print("Download skipped.")
                     break
                 elif decision=='y' or decision=='Y':

--- a/kuwala/pipelines/population-density/src/Processor.py
+++ b/kuwala/pipelines/population-density/src/Processor.py
@@ -1,6 +1,7 @@
 import math
 import os
 import time
+from datetime import date as dte
 from functools import reduce
 from pyspark.sql import SparkSession
 from pyspark.sql.functions import col, lit, sum
@@ -46,7 +47,23 @@ class Processor:
 
         df = reduce((lambda d1, d2: d1.join(d2, ['h3Index'], 'full').repartition(number_of_partitions, 'h3Index')), dfs)
 
-        df.write.mode('overwrite').parquet(output_dir + 'result.parquet')
+        today=str(dte.today())
+
+        if (os.path.isdir(output_dir + 'result.parquet'+'_'+today)):
+            print("parquet files already exist")
+            deci=''
+            while(deci!='n' or deci!='N' or deci!='y' or deci!='Y'):
+                deci=input("do you want to overwrite? [Y] or skip donwload [N]?   ")
+                if deci=='n' or deci=='N':
+                    print("Download skipped.")
+                    break
+                elif deci=='y' or deci=='Y':
+                    df.write.mode('overwrite').parquet(output_dir + 'result.parquet'+'_'+today)
+                    print("parquet overwritted")  
+                    break
+
+        else:
+            df.write.mode('overwrite').parquet(output_dir + 'result.parquet'+'_'+today)   
 
         end_time = time.time()
 

--- a/kuwala/pipelines/population-density/src/Processor.py
+++ b/kuwala/pipelines/population-density/src/Processor.py
@@ -49,21 +49,21 @@ class Processor:
 
         today=str(dte.today())
 
-        if (os.path.isdir(output_dir + 'result.parquet'+'_'+today)):
+        if (os.path.isdir(output_dir + 'result'+'_'+today+'.parquet')):
             print("parquet files already exist")
-            deci=''
-            while(deci!='n' or deci!='N' or deci!='y' or deci!='Y'):
-                deci=input("do you want to overwrite? [Y] or skip donwload [N]?   ")
-                if deci=='n' or deci=='N':
+            decision=''
+            while(decision!='n' or decision!='N' or decision!='y' or decision!='Y'):
+                decisionsion=input("do you want to overwrite? [Y] or skip download [N]? ")
+                if decisionsion=='n' or decisionsion=='N':
                     print("Download skipped.")
                     break
-                elif deci=='y' or deci=='Y':
-                    df.write.mode('overwrite').parquet(output_dir + 'result.parquet'+'_'+today)
+                elif decision=='y' or decision=='Y':
+                    df.write.mode('overwrite').parquet(output_dir + 'result'+'_'+today+'.parquet')
                     print("parquet overwritted")  
                     break
 
         else:
-            df.write.mode('overwrite').parquet(output_dir + 'result.parquet'+'_'+today)   
+            df.write.mode('overwrite').parquet(output_dir + 'result'+'_'+today+'.parquet')   
 
         end_time = time.time()
 

--- a/kuwala/pipelines/population-density/src/main.py
+++ b/kuwala/pipelines/population-density/src/main.py
@@ -11,6 +11,7 @@ if __name__ == '__main__':
     parser.add_argument('--continent', help='Continent of the file')
     parser.add_argument('--country', help='Country of the file')
     parser.add_argument('--demographic_groups', help='Demographic groups to be downloaded')
+    parser.add_argument('--population_density_date',help='Selected update date to process' )
     args = parser.parse_args()
 
     files, output_dir, updated_date = Downloader.start(args)

--- a/kuwala/pipelines/population-density/src/main.py
+++ b/kuwala/pipelines/population-density/src/main.py
@@ -11,7 +11,6 @@ if __name__ == '__main__':
     parser.add_argument('--continent', help='Continent of the file')
     parser.add_argument('--country', help='Country of the file')
     parser.add_argument('--demographic_groups', help='Demographic groups to be downloaded')
-    parser.add_argument('--population_density_date',help='Selected update date to process' )
     args = parser.parse_args()
 
     files, output_dir, updated_date = Downloader.start(args)

--- a/kuwala/pipelines/population-density/src/main.py
+++ b/kuwala/pipelines/population-density/src/main.py
@@ -13,7 +13,7 @@ if __name__ == '__main__':
     parser.add_argument('--demographic_groups', help='Demographic groups to be downloaded')
     args = parser.parse_args()
 
-    files, output_dir = Downloader.start(args)
+    files, output_dir, update_date = Downloader.start(args)
 
-    Processor.start(files, output_dir)
+    Processor.start(files, output_dir, update_date)
 

--- a/kuwala/pipelines/population-density/src/main.py
+++ b/kuwala/pipelines/population-density/src/main.py
@@ -13,7 +13,7 @@ if __name__ == '__main__':
     parser.add_argument('--demographic_groups', help='Demographic groups to be downloaded')
     args = parser.parse_args()
 
-    files, output_dir, update_date = Downloader.start(args)
+    files, output_dir, updated_date = Downloader.start(args)
 
-    Processor.start(files, output_dir, update_date)
+    Processor.start(files, output_dir, updated_date)
 


### PR DESCRIPTION
As in this [issue](https://github.com/kuwala-io/kuwala/issues/1), we need to add a mechanism to label each data with date and let the user know that some data from one country is already exist (so they won't download twice). As a response, in this pull request I added:
1) date in the created folder name (in the temporary files folder)
2) mechanism to choose if we want to overwrite the data, or skip the download if we already have the data

Thank you^^