### PR TITLE
🔀📖 Transformation catalog API and transformation block structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ venv/
 !**/.gitkeep
 
 tmp
+logs
 env
 !.env.local
 __pycache__

--- a/kuwala/core/backend/app/controller/dbt_controller.py
+++ b/kuwala/core/backend/app/controller/dbt_controller.py
@@ -39,7 +39,14 @@ def create_empty_dbt_project(data_source_id: str, warehouse: str, target_dir: st
 
         file.close()
 
-    packages_yaml["packages"] = [dict(package="dbt-labs/codegen", version="0.5.0")]
+    packages_yaml["packages"] = [
+        dict(package="dbt-labs/codegen", version="0.5.0"),
+        dict(
+            local=os.path.join(
+                target_dir, "../../../../core/backend/app/dbt/kuwala_blocks"
+            )
+        ),
+    ]
 
     with open(packages_file_path, "w") as file:
         yaml.safe_dump(packages_yaml, file, indent=4)

--- a/kuwala/core/backend/app/controller/transformation_block_controller.py
+++ b/kuwala/core/backend/app/controller/transformation_block_controller.py
@@ -1,0 +1,293 @@
+import itertools
+import os
+import subprocess
+from typing import List, Union
+
+from controller.data_source.data_source import (
+    get_data_source_and_data_catalog_item_id,
+    get_table_preview,
+)
+from database.crud.common import generate_object_id, get_object_by_id
+from database.database import Base, get_db
+from database.models.data_block import DataBlock
+from database.models.transformation_block import TransformationBlock
+from database.schemas.transformation_block import TransformationBlockCreate
+from fastapi import Depends, HTTPException
+import oyaml as yaml
+from sqlalchemy.orm import Session
+
+
+def get_dbt_dir(data_source_id: str) -> str:
+    script_dir = os.path.dirname(__file__)
+
+    return os.path.join(
+        script_dir, f"../../../../tmp/kuwala/backend/dbt/{data_source_id}"
+    )
+
+
+def args_to_string(args: dict) -> str:
+    encoded_dict = dict()
+
+    def encode_yaml_parameter(string: str) -> str:
+        return (
+            string.replace(" ", "YAML_STRING_SPACE")
+            .replace("(", "YAML_STRING_ROUND_BRACKET_OPEN")
+            .replace(")", "YAML_STRING_ROUND_BRACKET_CLOSED")
+        )
+
+    for key in args.keys():
+        if isinstance(args[key], str):
+            encoded_dict[key] = encode_yaml_parameter(args[key])
+        else:
+            encoded_dict[key] = []
+
+            for item in args[key]:
+                encoded_dict[key].append(encode_yaml_parameter(item))
+
+    return str(encoded_dict)
+
+
+def create_model(
+    dbt_dir: str,
+    name: str,
+    base_data_blocks: list[DataBlock],
+    base_transformation_blocks: list[TransformationBlock],
+    transformation_block_id: str,
+    transformation_catalog_item_id: str,
+    args: dict,
+    db: Session,
+):
+    base_data_block = base_data_blocks[0]
+    _, data_catalog_item_id = get_data_source_and_data_catalog_item_id(
+        data_source_id=base_data_block.data_source_id, db=db
+    )
+    schema_name = base_data_block.schema_name
+    table_name = base_data_block.table_name
+
+    if data_catalog_item_id == "bigquery":
+        schema_name = base_data_block.dataset_name
+
+    output = subprocess.run(
+        f"dbt run-operation {transformation_catalog_item_id} --args '{args_to_string(args)}' --profiles-dir .",
+        cwd=dbt_dir,
+        shell=True,
+        capture_output=True,
+    )
+    dbt_model_dir = f"{dbt_dir}/models/marts/{schema_name}/{table_name}"
+    dbt_model = output.stdout.decode("utf8").split("KUWALA TRANSFORMATION")[1][:-5]
+    base_id = (
+        base_data_block.id
+        if not base_transformation_blocks or len(base_transformation_blocks)
+        else "_".join(list(map(lambda tb: tb.id, base_transformation_blocks)))
+    )
+    dbt_model_name = f"{'_'.join(map(lambda n: n.lower(), name.split()))}_{transformation_block_id}_{base_id}"
+
+    with open(f"{dbt_model_dir}/{dbt_model_name}.sql", "w+") as file:
+        file.write(dbt_model)
+        file.close()
+
+    return dbt_model_dir, dbt_model_name
+
+
+def create_model_yaml(dbt_dir: str, dbt_model_dir: str, dbt_model_name: str):
+    args = dict(model_name=dbt_model_name)
+    output = subprocess.run(
+        f"dbt run-operation generate_model_yaml --args '{args}' --profiles-dir .",
+        cwd=dbt_dir,
+        shell=True,
+        capture_output=True,
+    )
+    source_yml = yaml.safe_load(
+        f"version: 2{output.stdout.decode('utf8').split('version: 2')[1][:-5]}"
+    )
+
+    with open(f"{dbt_model_dir}/{dbt_model_name}.yml", "w+") as file:
+        yaml.safe_dump(source_yml, file, indent=4)
+        file.close()
+
+
+def get_input_block(db: Session, object_id: str) -> Base:
+    try:
+        return get_object_by_id(db=db, model=DataBlock, object_id=object_id)
+    except HTTPException:
+        return get_object_by_id(db=db, model=TransformationBlock, object_id=object_id)
+
+
+def get_base_blocks(
+    db: Session,
+    input_block_ids: list[str],
+) -> Union[tuple[List[Base], List[Base]], tuple[List[Base], None]]:
+    input_blocks = list(
+        map(
+            lambda object_id: get_input_block(db=db, object_id=object_id),
+            input_block_ids,
+        )
+    )
+    input_blocks_types = list(map(lambda ib: type(ib).__name__, input_blocks))
+    number_of_data_blocks = len(
+        list(
+            filter(
+                lambda input_block_type: input_block_type == "DataBlock",
+                input_blocks_types,
+            )
+        )
+    )
+    number_of_transformation_blocks = len(
+        list(
+            filter(
+                lambda input_block_type: input_block_type == "TransformationBlock",
+                input_blocks_types,
+            )
+        )
+    )
+
+    if number_of_transformation_blocks == 0:
+        return input_blocks, None
+    elif number_of_data_blocks == 0:
+        base_data_blocks = list()
+
+        for input_block in input_blocks:
+            base_data_block = None
+            next_parent_block = input_block
+
+            while not base_data_block:
+                base_data_block, next_parent_block = get_base_blocks(
+                    db=db, input_block_ids=next_parent_block.input_block_ids
+                )
+
+            base_data_blocks.append(base_data_block)
+
+        return list(itertools.chain(*base_data_blocks)), input_blocks
+
+    raise HTTPException(
+        status_code=400,
+        detail="Cannot find base data block",
+    )
+
+
+def get_data_source_id(base_data_blocks: list[DataBlock]) -> str:
+    data_source_ids = list(set(map(lambda bdb: bdb.data_source_id, base_data_blocks)))
+
+    if len(data_source_ids) == 1:
+        return data_source_ids[0]
+
+    raise HTTPException(
+        status_code=400,
+        detail="Transformation is based on two different data sources which is currently not supported",
+    )
+
+
+def get_dbt_model_args(
+    args: dict,
+    base_data_blocks: list[DataBlock],
+    base_transformation_blocks: list[TransformationBlock],
+    db: Session,
+) -> dict:
+    if len(base_data_blocks) == 1 and not base_transformation_blocks:
+        args["dbt_model"] = base_data_blocks[0].dbt_model
+    elif "left_block" not in args.keys():
+        args["dbt_model"] = base_transformation_blocks[0].dbt_model
+    else:
+        try:
+            left_block = get_object_by_id(
+                db=db, model=DataBlock, object_id=args["left_block"]
+            )
+        except HTTPException:
+            left_block = get_object_by_id(
+                db=db, model=TransformationBlock, object_id=args["left_block"]
+            )
+
+        try:
+            right_block = get_object_by_id(
+                db=db, model=DataBlock, object_id=args["right_block"]
+            )
+        except HTTPException:
+            right_block = get_object_by_id(
+                db=db, model=TransformationBlock, object_id=args["right_block"]
+            )
+
+        del args["left_block"]
+        del args["right_block"]
+
+        args["dbt_model_left"] = left_block.dbt_model
+        args["dbt_model_right"] = right_block.dbt_model
+
+    return args
+
+
+def create_transformation_block(
+    transformation_block: TransformationBlockCreate,
+    db: Session,
+):
+    transformation_block_id = generate_object_id()
+    base_data_blocks, base_transformation_blocks = get_base_blocks(
+        db=db,
+        input_block_ids=transformation_block.input_block_ids,
+    )
+    data_source_id = get_data_source_id(base_data_blocks)
+    args = dict()
+
+    for mp in transformation_block.macro_parameters:
+        args[mp.id] = mp.value
+
+    args = get_dbt_model_args(
+        args=args,
+        base_data_blocks=base_data_blocks,
+        base_transformation_blocks=base_transformation_blocks,
+        db=db,
+    )
+    dbt_dir = get_dbt_dir(data_source_id=data_source_id)
+    dbt_model_dir, dbt_model_name = create_model(
+        db=db,
+        name=transformation_block.name,
+        dbt_dir=dbt_dir,
+        transformation_block_id=transformation_block_id,
+        base_data_blocks=base_data_blocks,
+        base_transformation_blocks=base_transformation_blocks,
+        transformation_catalog_item_id=transformation_block.transformation_catalog_item_id,
+        args=args,
+    )
+
+    output = subprocess.run(
+        f"dbt run --select {dbt_model_name} --profiles-dir .",
+        cwd=dbt_dir,
+        shell=True,
+        capture_output=True,
+    )
+    number_of_errors = int(
+        output.stdout.decode("utf8").split("ERROR=")[1].split("SKIP=")[0][:-1]
+    )
+
+    if number_of_errors:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Failed to run dbt model with {number_of_errors} {'errors' if number_of_errors > 1 else 'error'}",
+        )
+
+    create_model_yaml(
+        dbt_dir=dbt_dir, dbt_model_dir=dbt_model_dir, dbt_model_name=dbt_model_name
+    )
+
+    return data_source_id, transformation_block_id, dbt_model_name
+
+
+def get_transformation_block_preview(
+    transformation_block_id: str,
+    limit_columns: int = None,
+    limit_rows: int = None,
+    db: Session = Depends(get_db),
+):
+    transformation_block = get_object_by_id(
+        db=db, model=TransformationBlock, object_id=transformation_block_id
+    )
+
+    return get_table_preview(
+        data_source_id=transformation_block.data_source_id,
+        schema_name="dbt_kuwala",
+        dataset_name="dbt_kuwala",
+        table_name=transformation_block.dbt_model,
+        columns=None,
+        limit_columns=limit_columns,
+        limit_rows=limit_rows,
+        db=db,
+    )

--- a/kuwala/core/backend/app/database/crud/common.py
+++ b/kuwala/core/backend/app/database/crud/common.py
@@ -1,12 +1,12 @@
-import uuid
-
 from database.database import Base
 from fastapi import HTTPException
+import shortuuid
 from sqlalchemy.orm import Session
+from sqlalchemy.sql import text
 
 
 def generate_object_id() -> str:
-    return str(uuid.uuid4()).replace("-", "")
+    return shortuuid.ShortUUID().random(length=6).lower()
 
 
 def get_object_by_id(db: Session, model: Base, object_id: str) -> Base:
@@ -21,7 +21,10 @@ def get_object_by_id(db: Session, model: Base, object_id: str) -> Base:
     return db_object
 
 
-def get_all_objects(db: Session, model: Base) -> [Base]:
+def get_all_objects(db: Session, model: Base, where: str = None) -> [Base]:
+    if where is not None:
+        return db.query(model).where(text(where)).all()
+
     return db.query(model).all()
 
 

--- a/kuwala/core/backend/app/database/crud/data_block.py
+++ b/kuwala/core/backend/app/database/crud/data_block.py
@@ -1,4 +1,3 @@
-from database.crud.common import generate_object_id
 from sqlalchemy.orm import Session
 
 from ..database import add_and_commit_to_db
@@ -7,10 +6,10 @@ from ..schemas import data_block as schemas
 
 
 def create_data_block(
-    db: Session, data_block: schemas.DataBlockCreate, dbt_model: str
+    db: Session, data_block: schemas.DataBlockCreate, generated_id: str, dbt_model: str
 ) -> models.DataBlock:
     db_data_block = models.DataBlock(
-        id=generate_object_id(),
+        id=generated_id,
         data_source_id=data_block.data_source_id,
         name=data_block.name,
         dbt_model=dbt_model,

--- a/kuwala/core/backend/app/database/crud/transformation_block.py
+++ b/kuwala/core/backend/app/database/crud/transformation_block.py
@@ -1,0 +1,31 @@
+from sqlalchemy.orm import Session
+
+from ..database import add_and_commit_to_db
+from ..models import transformation_block as models
+from ..schemas import transformation_block as schemas
+
+
+def create_transformation_block(
+    db: Session,
+    transformation_block: schemas.TransformationBlockCreate,
+    data_source_id: str,
+    generated_id: str,
+    dbt_model: str,
+) -> models.TransformationBlock:
+    macro_parameters = list(
+        map(lambda mp: mp.dict(), transformation_block.macro_parameters)
+    )
+
+    db_data_block = models.TransformationBlock(
+        id=generated_id,
+        transformation_catalog_item_id=transformation_block.transformation_catalog_item_id,
+        data_source_id=data_source_id,
+        input_block_ids=transformation_block.input_block_ids,
+        macro_parameters=macro_parameters,
+        name=transformation_block.name,
+        dbt_model=dbt_model,
+    )
+
+    add_and_commit_to_db(db=db, model=db_data_block)
+
+    return db_data_block

--- a/kuwala/core/backend/app/database/crud/transformation_catalog.py
+++ b/kuwala/core/backend/app/database/crud/transformation_catalog.py
@@ -1,0 +1,29 @@
+from sqlalchemy.orm import Session
+
+from ..database import add_and_commit_to_db
+from ..models import transformation_catalog as models
+from ..schemas import transformation_catalog as schemas
+
+
+def create_transformation_catalog_item(
+    db: Session,
+    transformation_catalog_item: schemas.TransformationCatalogItemCreate,
+) -> models.TransformationCatalogItem:
+    db_transformation_catalog_item = models.TransformationCatalogItem(
+        id=transformation_catalog_item.id,
+        category=transformation_catalog_item.category,
+        name=transformation_catalog_item.name,
+        icon=transformation_catalog_item.icon,
+        description=transformation_catalog_item.description,
+        required_column_types=transformation_catalog_item.required_column_types,
+        optional_column_types=transformation_catalog_item.optional_column_types,
+        min_number_of_input_blocks=transformation_catalog_item.min_number_of_input_blocks,
+        max_number_of_input_blocks=transformation_catalog_item.max_number_of_input_blocks,
+        macro_parameters=transformation_catalog_item.macro_parameters,
+        examples_before=transformation_catalog_item.examples_before,
+        examples_after=transformation_catalog_item.examples_after,
+    )
+
+    add_and_commit_to_db(db=db, model=db_transformation_catalog_item)
+
+    return db_transformation_catalog_item

--- a/kuwala/core/backend/app/database/crud/transformation_catalog_category.py
+++ b/kuwala/core/backend/app/database/crud/transformation_catalog_category.py
@@ -1,0 +1,20 @@
+from sqlalchemy.orm import Session
+
+from ..database import add_and_commit_to_db
+from ..models import transformation_catalog_category as models
+from ..schemas import transformation_catalog_category as schemas
+
+
+def create_transformation_catalog_category(
+    db: Session,
+    transformation_catalog_category: schemas.TransformationCatalogCategoryCreate,
+) -> models.TransformationCatalogCategory:
+    db_transformation_catalog_category = models.TransformationCatalogCategory(
+        id=transformation_catalog_category.id,
+        name=transformation_catalog_category.name,
+        icon=transformation_catalog_category.icon,
+    )
+
+    add_and_commit_to_db(db=db, model=db_transformation_catalog_category)
+
+    return db_transformation_catalog_category

--- a/kuwala/core/backend/app/database/models/data_block.py
+++ b/kuwala/core/backend/app/database/models/data_block.py
@@ -8,7 +8,7 @@ class DataBlock(Base):
     __tablename__ = "data_blocks"
 
     id = Column(String, primary_key=True, index=True)
-    data_source_id = Column(String, ForeignKey("data_sources.id"))
+    data_source_id = Column(String, ForeignKey("data_sources.id"), nullable=False)
     name = Column(String, nullable=False)
     dbt_model = Column(String, nullable=False)
     table_name = Column(String, nullable=False)

--- a/kuwala/core/backend/app/database/models/data_source.py
+++ b/kuwala/core/backend/app/database/models/data_source.py
@@ -8,6 +8,8 @@ class DataSource(Base):
     __tablename__ = "data_sources"
 
     id = Column(String, primary_key=True, index=True)
-    data_catalog_item_id = Column(String, ForeignKey("data_catalog_items.id"))
+    data_catalog_item_id = Column(
+        String, ForeignKey("data_catalog_items.id"), nullable=False
+    )
     connection_parameters = Column(MutableList.as_mutable(JSON), nullable=False)
     connected = Column(Boolean, nullable=False)

--- a/kuwala/core/backend/app/database/models/transformation_block.py
+++ b/kuwala/core/backend/app/database/models/transformation_block.py
@@ -1,0 +1,19 @@
+from sqlalchemy import JSON, Column, ForeignKey, String
+from sqlalchemy.dialects.postgresql import ARRAY
+from sqlalchemy.ext.mutable import MutableList
+
+from ..database import Base
+
+
+class TransformationBlock(Base):
+    __tablename__ = "transformation_blocks"
+
+    id = Column(String, primary_key=True, index=True)
+    transformation_catalog_item_id = Column(
+        String, ForeignKey("transformation_catalog_items.id"), nullable=False
+    )
+    data_source_id = Column(String, ForeignKey("data_sources.id"), nullable=False)
+    input_block_ids = Column(ARRAY(String))
+    macro_parameters = Column(MutableList.as_mutable(JSON), nullable=False)
+    name = Column(String, nullable=False)
+    dbt_model = Column(String, nullable=False)

--- a/kuwala/core/backend/app/database/models/transformation_catalog.py
+++ b/kuwala/core/backend/app/database/models/transformation_catalog.py
@@ -1,0 +1,22 @@
+from sqlalchemy import JSON, Column, ForeignKey, Integer, String
+from sqlalchemy.dialects.postgresql import ARRAY
+from sqlalchemy.ext.mutable import MutableList
+
+from ..database import Base
+
+
+class TransformationCatalogItem(Base):
+    __tablename__ = "transformation_catalog_items"
+
+    id = Column(String, primary_key=True, index=True)
+    category = Column(String, ForeignKey("transformation_catalog_categories.id"))
+    name = Column(String, nullable=False)
+    icon = Column(String, nullable=False)
+    description = Column(String, nullable=False)
+    required_column_types = Column(ARRAY(String), nullable=False)
+    optional_column_types = Column(ARRAY(String), nullable=False)
+    min_number_of_input_blocks = Column(Integer, nullable=False)
+    max_number_of_input_blocks = Column(Integer, nullable=False)
+    macro_parameters = Column(MutableList.as_mutable(JSON), nullable=False)
+    examples_before = Column(JSON, nullable=False)
+    examples_after = Column(JSON, nullable=False)

--- a/kuwala/core/backend/app/database/models/transformation_catalog_category.py
+++ b/kuwala/core/backend/app/database/models/transformation_catalog_category.py
@@ -1,0 +1,11 @@
+from sqlalchemy import Column, String
+
+from ..database import Base
+
+
+class TransformationCatalogCategory(Base):
+    __tablename__ = "transformation_catalog_categories"
+
+    id = Column(String, primary_key=True, index=True)
+    name = Column(String, nullable=False)
+    icon = Column(String, nullable=False)

--- a/kuwala/core/backend/app/database/schemas/transformation_block.py
+++ b/kuwala/core/backend/app/database/schemas/transformation_block.py
@@ -1,0 +1,29 @@
+from typing import List, Union
+
+from pydantic import BaseModel, Json
+
+
+class TransformationBlockBase(BaseModel):
+    id: str
+    transformation_catalog_item_id: str
+    data_source_id: str
+    input_block_ids: List[str]
+    macro_parameters: Json
+    name: str
+
+
+class TransformationBlock(TransformationBlockBase):
+    class Config:
+        orm_mode = True
+
+
+class MacroParameter(BaseModel):
+    id: str
+    value: Union[str, List[str]]
+
+
+class TransformationBlockCreate(BaseModel):
+    transformation_catalog_item_id: str
+    input_block_ids: List[str]
+    macro_parameters: List[MacroParameter]
+    name: str

--- a/kuwala/core/backend/app/database/schemas/transformation_catalog.py
+++ b/kuwala/core/backend/app/database/schemas/transformation_catalog.py
@@ -1,0 +1,27 @@
+from typing import List
+
+from pydantic import BaseModel, Json
+
+
+class TransformationCatalogItemBase(BaseModel):
+    id: str
+    category: str
+    name: str
+    icon: str
+    description: str
+    required_column_types: List[str]
+    optional_column_types: List[str]
+    min_number_of_input_blocks: int
+    max_number_of_input_blocks: int
+    macro_parameters: Json
+    examples_before: Json
+    examples_after: Json
+
+
+class TransformationCatalogItem(TransformationCatalogItemBase):
+    class Config:
+        orm_mode = True
+
+
+class TransformationCatalogItemCreate(TransformationCatalogItemBase):
+    pass

--- a/kuwala/core/backend/app/database/schemas/transformation_catalog_category.py
+++ b/kuwala/core/backend/app/database/schemas/transformation_catalog_category.py
@@ -1,0 +1,16 @@
+from pydantic import BaseModel
+
+
+class TransformationCatalogCategoryBase(BaseModel):
+    id: str
+    name: str
+    icon: str
+
+
+class TransformationCatalogCategory(TransformationCatalogCategoryBase):
+    class Config:
+        orm_mode = True
+
+
+class TransformationCatalogCategoryCreate(TransformationCatalogCategoryBase):
+    pass

--- a/kuwala/core/backend/app/dbt/kuwala_blocks/.gitignore
+++ b/kuwala/core/backend/app/dbt/kuwala_blocks/.gitignore
@@ -1,0 +1,4 @@
+
+target/
+dbt_packages/
+logs/

--- a/kuwala/core/backend/app/dbt/kuwala_blocks/README.md
+++ b/kuwala/core/backend/app/dbt/kuwala_blocks/README.md
@@ -1,0 +1,15 @@
+Welcome to your new dbt project!
+
+### Using the starter project
+
+Try running the following commands:
+- dbt run
+- dbt test
+
+
+### Resources:
+- Learn more about dbt [in the docs](https://docs.getdbt.com/docs/introduction)
+- Check out [Discourse](https://discourse.getdbt.com/) for commonly asked questions and answers
+- Join the [chat](https://community.getdbt.com/) on Slack for live discussions and support
+- Find [dbt events](https://events.getdbt.com) near you
+- Check out [the blog](https://blog.getdbt.com/) for the latest news on dbt's development and best practices

--- a/kuwala/core/backend/app/dbt/kuwala_blocks/dbt_project.yml
+++ b/kuwala/core/backend/app/dbt/kuwala_blocks/dbt_project.yml
@@ -1,0 +1,38 @@
+
+# Name your project! Project names should contain only lowercase characters
+# and underscores. A good package name should reflect your organization's
+# name or the intended use of these models
+name: 'kuwala_blocks'
+version: '1.0.0'
+config-version: 2
+
+# This setting configures which "profile" dbt uses for this project.
+profile: 'kuwala_blocks'
+
+# These configurations specify where dbt should look for different types of files.
+# The `model-paths` config, for example, states that models in this project can be
+# found in the "models/" directory. You probably won't need to change these!
+model-paths: ["models"]
+analysis-paths: ["analyses"]
+test-paths: ["tests"]
+seed-paths: ["seeds"]
+macro-paths: ["macros"]
+snapshot-paths: ["snapshots"]
+
+target-path: "target"  # directory which will store compiled SQL files
+clean-targets:         # directories to be removed by `dbt clean`
+  - "target"
+  - "dbt_packages"
+
+
+# Configuring models
+# Full documentation: https://docs.getdbt.com/docs/configuring-models
+
+# In this example config, we tell dbt to build all models in the example/ directory
+# as tables. These settings can be overridden in the individual model files
+# using the `{{ config(...) }}` macro.
+models:
+  kuwala_blocks:
+    # Config indicated by + and applies to all files under models/example/
+    example:
+      +materialized: view

--- a/kuwala/core/backend/app/dbt/kuwala_blocks/macros/general/is_false.sql
+++ b/kuwala/core/backend/app/dbt/kuwala_blocks/macros/general/is_false.sql
@@ -1,0 +1,15 @@
+{% macro is_false(dbt_model, column) %}
+    {% set rel = '{{ ref("' + dbt_model + '") }}' %}
+
+    {% set query %}
+        -- KUWALA TRANSFORMATION
+        SELECT *
+        FROM {{ rel }}
+        WHERE {{ column }} = False
+    {% endset %}
+
+    {% if execute %}
+        {{ log(query, info=True) }}
+        {% do return(query) %}
+    {% endif %}
+{% endmacro %}

--- a/kuwala/core/backend/app/dbt/kuwala_blocks/macros/general/is_true.sql
+++ b/kuwala/core/backend/app/dbt/kuwala_blocks/macros/general/is_true.sql
@@ -1,0 +1,15 @@
+{% macro is_true(dbt_model, column) %}
+    {% set rel = '{{ ref("' + dbt_model + '") }}' %}
+
+    {% set query %}
+        -- KUWALA TRANSFORMATION
+        SELECT *
+        FROM {{ rel }}
+        WHERE {{ column }} = True
+    {% endset %}
+
+    {% if execute %}
+        {{ log(query, info=True) }}
+        {% do return(query) %}
+    {% endif %}
+{% endmacro %}

--- a/kuwala/core/backend/app/dbt/kuwala_blocks/macros/merging/join_by_id.sql
+++ b/kuwala/core/backend/app/dbt/kuwala_blocks/macros/merging/join_by_id.sql
@@ -1,0 +1,17 @@
+{% macro join_by_id(dbt_model_left, dbt_model_right, column_left, column_right, join_type) %}
+    {% set join_type_value = get_join_type_value(join_type) %}
+    {% set join_condition = get_join_condition(column_left, column_right) %}
+    {% set rel_left = '{{ ref("' + dbt_model_left + '") }}' %}
+    {% set rel_right = '{{ ref("' + dbt_model_right + '") }}' %}
+
+    {% set query %}
+        -- KUWALA TRANSFORMATION
+        SELECT *
+        FROM {{ rel_left }} AS rel1 {{ join_type_value }} {{ rel_right }} AS rel2 {{ join_condition }}
+    {% endset %}
+
+    {% if execute %}
+        {{ log(query, info=True) }}
+        {% do return(query) %}
+    {% endif %}
+{% endmacro %}

--- a/kuwala/core/backend/app/dbt/kuwala_blocks/macros/merging/union.sql
+++ b/kuwala/core/backend/app/dbt/kuwala_blocks/macros/merging/union.sql
@@ -1,0 +1,16 @@
+{% macro union(dbt_model_left, dbt_model_right) %}
+    {% set rel_left = '{{ ref("' + dbt_model_left + '") }}' %}
+    {% set rel_right = '{{ ref("' + dbt_model_right + '") }}' %}
+
+    {% set query %}
+        -- KUWALA TRANSFORMATION
+        SELECT * FROM {{ rel_left }}
+        UNION
+        SELECT * FROM {{ rel_right }}
+    {% endset %}
+
+    {% if execute %}
+        {{ log(query, info=True) }}
+        {% do return(query) %}
+    {% endif %}
+{% endmacro %}

--- a/kuwala/core/backend/app/dbt/kuwala_blocks/macros/numeric/add_columns.sql
+++ b/kuwala/core/backend/app/dbt/kuwala_blocks/macros/numeric/add_columns.sql
@@ -1,0 +1,18 @@
+{% macro add_columns(dbt_model, columns, result_name) %}
+    {% set rel = '{{ ref("' + dbt_model + '") }}' %}
+
+    {%- set calculation -%}
+        {% for column in columns %}{{ column }} + {% endfor %}
+    {%- endset -%}
+
+    {% set query %}
+        -- KUWALA TRANSFORMATION
+        SELECT *, {{ calculation[:-3] }} AS {{ result_name }}
+        FROM {{ rel }}
+    {% endset %}
+
+    {% if execute %}
+        {{ log(query, info=True) }}
+        {% do return(query) %}
+    {% endif %}
+{% endmacro %}

--- a/kuwala/core/backend/app/dbt/kuwala_blocks/macros/numeric/compare_with_number.sql
+++ b/kuwala/core/backend/app/dbt/kuwala_blocks/macros/numeric/compare_with_number.sql
@@ -1,0 +1,16 @@
+{% macro compare_with_number(dbt_model, column, comparator, comparison_value) %}
+    {% set comparator_value = get_comparator_value(comparator) %}
+    {% set rel = '{{ ref("' + dbt_model + '") }}' %}
+
+    {% set query %}
+        -- KUWALA TRANSFORMATION
+        SELECT *
+        FROM {{ rel }}
+        WHERE {{ column }} {{ comparator_value }} {{ comparison_value }}
+    {% endset %}
+
+    {% if execute %}
+        {{ log(query, info=True) }}
+        {% do return(query) %}
+    {% endif %}
+{% endmacro %}

--- a/kuwala/core/backend/app/dbt/kuwala_blocks/macros/text/contains_keyword.sql
+++ b/kuwala/core/backend/app/dbt/kuwala_blocks/macros/text/contains_keyword.sql
@@ -1,0 +1,15 @@
+{% macro contains_keyword(dbt_model, column, keyword) %}
+    {% set rel = '{{ ref("' + dbt_model + '") }}' %}
+
+    {% set query %}
+        -- KUWALA TRANSFORMATION
+        SELECT *
+        FROM {{ rel }}
+        WHERE {{ column }} LIKE '%{{ decode_yaml_parameter(keyword) }}%'
+    {% endset %}
+
+    {% if execute %}
+        {{ log(query, info=True) }}
+        {% do return(query) %}
+    {% endif %}
+{% endmacro %}

--- a/kuwala/core/backend/app/dbt/kuwala_blocks/macros/text/filter_by_keywords.sql
+++ b/kuwala/core/backend/app/dbt/kuwala_blocks/macros/text/filter_by_keywords.sql
@@ -1,0 +1,19 @@
+{% macro filter_by_keywords(dbt_model, column, keywords) %}
+    {% set rel = '{{ ref("' + dbt_model + '") }}' %}
+
+    {%- set parsed_keywords -%}
+        {% for keyword in keywords %}'{{ decode_yaml_parameter(keyword) }}',{% endfor %}
+    {%- endset -%}
+
+    {% set query %}
+        -- KUWALA TRANSFORMATION
+        SELECT *
+        FROM {{ rel }}
+        WHERE {{ column }} IN ({{ parsed_keywords[:-1] }})
+    {% endset %}
+
+    {% if execute %}
+        {{ log(query, info=True) }}
+        {% do return(query) %}
+    {% endif %}
+{% endmacro %}

--- a/kuwala/core/backend/app/dbt/kuwala_blocks/macros/text/filter_by_regex.sql
+++ b/kuwala/core/backend/app/dbt/kuwala_blocks/macros/text/filter_by_regex.sql
@@ -1,0 +1,19 @@
+{% macro filter_by_regex(dbt_model, column, regex) %}
+    {% set rel = '{{ ref("' + dbt_model + '") }}' %}
+
+    {% set query %}
+        -- KUWALA TRANSFORMATION
+        SELECT *
+        FROM {{ rel }}
+        {% if target.type == 'bigquery' %}
+            WHERE REGEXP_CONTAINS({{ column }}, '{{ regex }}')
+        {% else %}
+            WHERE {{ column }} ~ '{{ regex }}'
+        {% endif %}
+    {% endset %}
+
+    {% if execute %}
+        {{ log(query, info=True) }}
+        {% do return(query) %}
+    {% endif %}
+{% endmacro %}

--- a/kuwala/core/backend/app/dbt/kuwala_blocks/macros/time/compare_with_date.sql
+++ b/kuwala/core/backend/app/dbt/kuwala_blocks/macros/time/compare_with_date.sql
@@ -1,0 +1,16 @@
+{% macro compare_with_date(dbt_model, column, comparator, comparison_date) %}
+    {% set comparator_value = get_comparator_value(comparator) %}
+    {% set rel = '{{ ref("' + dbt_model + '") }}' %}
+
+    {% set query %}
+        -- KUWALA TRANSFORMATION
+        SELECT *
+        FROM {{ rel }}
+        WHERE {{ column }} {{ comparator_value }} '{{ comparison_date }}'
+    {% endset %}
+
+    {% if execute %}
+        {{ log(query, info=True) }}
+        {% do return(query) %}
+    {% endif %}
+{% endmacro %}

--- a/kuwala/core/backend/app/dbt/kuwala_blocks/macros/utils/decode_yaml_parameter.sql
+++ b/kuwala/core/backend/app/dbt/kuwala_blocks/macros/utils/decode_yaml_parameter.sql
@@ -1,0 +1,10 @@
+{% macro decode_yaml_parameter(string) %}
+    {% if execute %}
+        {% do return(
+            string |
+            replace("YAML_STRING_SPACE", " ") |
+            replace("YAML_STRING_ROUND_BRACKET_OPEN", "(") |
+            replace("YAML_STRING_ROUND_BRACKET_CLOSED", ")")
+        ) %}
+    {% endif %}
+{% endmacro %}

--- a/kuwala/core/backend/app/dbt/kuwala_blocks/macros/utils/get_comparator_value.sql
+++ b/kuwala/core/backend/app/dbt/kuwala_blocks/macros/utils/get_comparator_value.sql
@@ -1,0 +1,22 @@
+{% macro get_comparator_value(comparator) %}
+    {% set value %}
+        {%- if comparator == "equal" -%}
+            =
+        {%- elif comparator == "not_equal" -%}
+            !=
+        {%- elif comparator == "less" -%}
+            <
+        {%- elif comparator == "greater" -%}
+            >
+        {%- elif comparator == "less_or_equal" -%}
+            <=
+        {%- elif comparator == "greater_or_equal" -%}
+            >=
+        {%- else -%}
+        {%- endif -%}
+    {% endset %}
+
+    {% if execute %}
+        {% do return(value) %}
+    {% endif %}
+{% endmacro %}

--- a/kuwala/core/backend/app/dbt/kuwala_blocks/macros/utils/get_join_condition.sql
+++ b/kuwala/core/backend/app/dbt/kuwala_blocks/macros/utils/get_join_condition.sql
@@ -1,0 +1,13 @@
+{% macro get_join_condition(column_left, column_right) %}
+    {% set value %}
+        {%- if column_left == column_right -%}
+            USING({{ column_left }})
+        {%- else -%}
+            ON rel1.{{ column_left }} = rel2.{{ column_right }}
+        {%- endif -%}
+    {% endset %}
+
+    {% if execute %}
+        {% do return(value) %}
+    {% endif %}
+{% endmacro %}

--- a/kuwala/core/backend/app/dbt/kuwala_blocks/macros/utils/get_join_type_value.sql
+++ b/kuwala/core/backend/app/dbt/kuwala_blocks/macros/utils/get_join_type_value.sql
@@ -1,0 +1,18 @@
+{% macro get_join_type_value(join_type) %}
+    {% set value %}
+        {%- if join_type == "inner" -%}
+            INNER JOIN
+        {%- elif join_type == "left" -%}
+            LEFT JOIN
+        {%- elif join_type == "right" -%}
+            RIGHT JOIN
+        {%- elif join_type == "full_outer" -%}
+            FULL OUTER JOIN
+        {%- else -%}
+        {%- endif -%}
+    {% endset %}
+
+    {% if execute %}
+        {% do return(value) %}
+    {% endif %}
+{% endmacro %}

--- a/kuwala/core/backend/app/main.py
+++ b/kuwala/core/backend/app/main.py
@@ -7,15 +7,34 @@ from time import sleep
 
 from database.crud.common import get_object_by_id
 from database.crud.data_catalog import create_data_catalog_item
+from database.crud.transformation_catalog import create_transformation_catalog_item
+from database.crud.transformation_catalog_category import (
+    create_transformation_catalog_category,
+)
 from database.database import Engine, get_db
+from database.models import (
+    transformation_catalog_category as transformation_catalog_category_models,
+)
 from database.models import data_block as data_block_models
 from database.models import data_catalog as data_catalog_models
 from database.models import data_source as data_source_models
+from database.models import transformation_block as transformation_block_models
+from database.models import transformation_catalog as transformation_catalog_models
+from database.schemas import (
+    transformation_catalog_category as transformation_catalog_category_schemas,
+)
 from database.schemas import data_catalog as data_catalog_schemas
+from database.schemas import transformation_catalog as transformation_catalog_schemas
 from fastapi import FastAPI
 import fastapi.exceptions
 from fastapi.middleware.cors import CORSMiddleware
-from routers import data_block, data_catalog, data_source
+from routers import (
+    data_block,
+    data_catalog,
+    data_source,
+    transformation_block,
+    transformation_catalog,
+)
 import sqlalchemy.exc
 import uvicorn
 
@@ -40,6 +59,8 @@ app.add_middleware(
 app.include_router(data_block.router)
 app.include_router(data_catalog.router)
 app.include_router(data_source.router)
+app.include_router(transformation_block.router)
+app.include_router(transformation_catalog.router)
 
 
 # Cannot be placed under `database/database.py` as it would create a circular import
@@ -50,11 +71,15 @@ def populate_db():
     sleep_time = 2
     error = None
 
+    # Create empty tables if they don't exist
     while not connected_to_db and current_try <= max_retries:
         try:
             data_block_models.Base.metadata.create_all(bind=Engine)
             data_catalog_models.Base.metadata.create_all(bind=Engine)
             data_source_models.Base.metadata.create_all(bind=Engine)
+            transformation_catalog_category_models.Base.metadata.create_all(bind=Engine)
+            transformation_catalog_models.Base.metadata.create_all(bind=Engine)
+            transformation_block_models.Base.metadata.create_all(bind=Engine)
 
             connected_to_db = True
         except sqlalchemy.exc.OperationalError as e:
@@ -70,30 +95,100 @@ def populate_db():
 
     db = next(get_db())
 
+    # Add data catalog items to database
     script_dir = os.path.dirname(__file__)
     file = open(os.path.join(script_dir, "./resources/data_catalog_items.json"))
     data_catalog_items = json.load(file)
 
-    for data_catalog_item in data_catalog_items:
+    for dci in data_catalog_items:
         try:
             get_object_by_id(
                 db=db,
                 model=data_catalog_models.DataCatalogItem,
-                object_id=data_catalog_item["id"],
+                object_id=dci["id"],
             )
         except fastapi.exceptions.HTTPException as e:
             if e.status_code == 404:
                 create_data_catalog_item(
                     db=db,
                     data_catalog_item=data_catalog_schemas.DataCatalogItemCreate(
-                        id=data_catalog_item["id"],
-                        name=data_catalog_item["name"],
-                        logo=data_catalog_item["logo"],
-                        connection_parameters=json.dumps(
-                            data_catalog_item["connection_parameters"]
-                        ),
+                        id=dci["id"],
+                        name=dci["name"],
+                        logo=dci["logo"],
+                        connection_parameters=json.dumps(dci["connection_parameters"]),
                     ),
                 )
+
+    # Add transformation catalog categories to database
+    file = open(
+        os.path.join(script_dir, "./resources/transformation_catalog/categories.json")
+    )
+    transformation_catalog_categories = json.load(file)
+
+    for tcc in transformation_catalog_categories:
+        try:
+            get_object_by_id(
+                db=db,
+                model=transformation_catalog_category_models.TransformationCatalogCategory,
+                object_id=tcc["id"],
+            )
+        except fastapi.exceptions.HTTPException as e:
+            if e.status_code == 404:
+                create_transformation_catalog_category(
+                    db=db,
+                    transformation_catalog_category=transformation_catalog_category_schemas.TransformationCatalogCategoryCreate(
+                        id=tcc["id"],
+                        name=tcc["name"],
+                        icon=tcc["icon"],
+                    ),
+                )
+
+    # Add transformation catalog items to database
+    transformation_catalog_path = os.path.join(
+        script_dir, "./resources/transformation_catalog"
+    )
+    transformation_catalog_categories = list(
+        filter(
+            lambda d: os.path.isdir(d),
+            map(
+                lambda d: f"{transformation_catalog_path}/{d}",
+                os.listdir(transformation_catalog_path),
+            ),
+        )
+    )
+
+    for tcc in transformation_catalog_categories:
+        transformations = list(map(lambda tr: f"{tcc}/{tr}", os.listdir(tcc)))
+
+        for t in transformations:
+            file = open(t)
+            t = json.load(file)
+
+            try:
+                get_object_by_id(
+                    db=db,
+                    model=transformation_catalog_models.TransformationCatalogItem,
+                    object_id=t["id"],
+                )
+            except fastapi.exceptions.HTTPException as e:
+                if e.status_code == 404:
+                    create_transformation_catalog_item(
+                        db=db,
+                        transformation_catalog_item=transformation_catalog_schemas.TransformationCatalogItemCreate(
+                            id=t["id"],
+                            category=t["category"],
+                            name=t["name"],
+                            icon=t["icon"],
+                            description=t["description"],
+                            required_column_types=t["required_column_types"],
+                            optional_column_types=t["optional_column_types"],
+                            min_number_of_input_blocks=t["min_number_of_input_blocks"],
+                            max_number_of_input_blocks=t["max_number_of_input_blocks"],
+                            macro_parameters=json.dumps(t["macro_parameters"]),
+                            examples_before=json.dumps(t["examples_before"]),
+                            examples_after=json.dumps(t["examples_after"]),
+                        ),
+                    )
 
 
 if __name__ == "__main__":

--- a/kuwala/core/backend/app/resources/transformation_catalog/categories.json
+++ b/kuwala/core/backend/app/resources/transformation_catalog/categories.json
@@ -1,0 +1,32 @@
+[
+  {
+    "id": "time",
+    "name": "Time",
+    "icon": "clock"
+  },
+  {
+    "id": "text",
+    "name": "Text",
+    "icon": "align-left"
+  },
+  {
+    "id": "numeric",
+    "name": "Numeric",
+    "icon": "calculator"
+  },
+  {
+    "id": "geo",
+    "name": "Geo",
+    "icon": "map-marked-alt"
+  },
+  {
+    "id": "merging",
+    "name": "Merging",
+    "icon": "link"
+  },
+  {
+    "id": "general",
+    "name": "General",
+    "icon": "cogs"
+  }
+]

--- a/kuwala/core/backend/app/resources/transformation_catalog/general/is_false.json
+++ b/kuwala/core/backend/app/resources/transformation_catalog/general/is_false.json
@@ -1,0 +1,75 @@
+{
+  "id": "is_false",
+  "category": "general",
+  "name": "Is false",
+  "icon": "times-circle",
+  "description": "With this transformation, you can filter a table based on a column that should be false.",
+  "required_column_types": ["boolean"],
+  "optional_column_types": [],
+  "min_number_of_input_blocks": 1,
+  "max_number_of_input_blocks": 1,
+  "macro_parameters": [
+    {
+      "id": "column",
+      "name": "Column",
+      "type": "text"
+    }
+  ],
+  "examples_before": [
+    {
+      "columns": [
+        "order_number",
+        "order_value",
+        "cancelled"
+      ],
+      "rows": [
+        [
+          "63472",
+          "39.99",
+          "false"
+        ],
+        [
+          "63473",
+          "74.97",
+          "true"
+        ],
+        [
+          "63474",
+          "99.99",
+          "false"
+        ],
+        [
+          "63475",
+          "9.99",
+          "false"
+        ]
+      ]
+    }
+  ],
+  "examples_after": [
+    {
+      "columns": [
+        "order_number",
+        "order_value",
+        "cancelled"
+      ],
+      "rows": [
+        [
+          "63472",
+          "39.99",
+          "false"
+        ],
+        [
+          "63474",
+          "99.99",
+          "false"
+        ],
+        [
+          "63475",
+          "9.99",
+          "false"
+        ]
+      ]
+    }
+  ]
+}

--- a/kuwala/core/backend/app/resources/transformation_catalog/general/is_true.json
+++ b/kuwala/core/backend/app/resources/transformation_catalog/general/is_true.json
@@ -1,0 +1,75 @@
+{
+  "id": "is_true",
+  "category": "general",
+  "name": "Is true",
+  "icon": "check-circle",
+  "description": "With this transformation, you can filter a table based on a column that should be true.",
+  "required_column_types": ["boolean"],
+  "optional_column_types": [],
+  "min_number_of_input_blocks": 1,
+  "max_number_of_input_blocks": 1,
+  "macro_parameters": [
+    {
+      "id": "column",
+      "name": "Column",
+      "type": "text"
+    }
+  ],
+  "examples_before": [
+    {
+      "columns": [
+        "order_number",
+        "order_value",
+        "paid"
+      ],
+      "rows": [
+        [
+          "63472",
+          "39.99",
+          "true"
+        ],
+        [
+          "63473",
+          "74.97",
+          "true"
+        ],
+        [
+          "63474",
+          "99.99",
+          "false"
+        ],
+        [
+          "63475",
+          "9.99",
+          "true"
+        ]
+      ]
+    }
+  ],
+  "examples_after": [
+    {
+      "columns": [
+        "order_number",
+        "order_value",
+        "paid"
+      ],
+      "rows": [
+        [
+          "63472",
+          "39.99",
+          "true"
+        ],
+        [
+          "63473",
+          "74.97",
+          "true"
+        ],
+        [
+          "63475",
+          "9.99",
+          "true"
+        ]
+      ]
+    }
+  ]
+}

--- a/kuwala/core/backend/app/resources/transformation_catalog/merging/join_by_id.json
+++ b/kuwala/core/backend/app/resources/transformation_catalog/merging/join_by_id.json
@@ -1,0 +1,129 @@
+{
+  "id": "join_by_id",
+  "category": "merging",
+  "name": "Join by ID",
+  "icon": "link",
+  "description": "With this transformation, you can join two tables by ID.",
+  "required_column_types": [],
+  "optional_column_types": ["text", "date", "numeric", "boolean"],
+  "min_number_of_input_blocks": 2,
+  "max_number_of_input_blocks": 2,
+  "macro_parameters": [
+    {
+      "id": "left_block",
+      "name": "Left block",
+      "type": "text"
+    }, {
+      "id": "right_block",
+      "name": "Right block",
+      "type": "text"
+    }, {
+      "id": "column_left",
+      "name": "Column left",
+      "type": "text"
+    }, {
+      "id": "column_right",
+      "name": "Column right",
+      "type": "text"
+    }, {
+      "id": "join_type",
+      "name": "Join type",
+      "type": "text",
+      "options": [
+        {
+          "id": "inner",
+          "name": "INNER JOIN"
+        }, {
+          "id": "left",
+          "name": "LEFT JOIN"
+        }, {
+          "id": "right",
+          "name": "RIGHT JOIN"
+        }, {
+          "id": "full_outer",
+          "name": "FULL OUTER JOIN"
+        }
+      ]
+    }
+  ],
+  "examples_before": [
+    {
+      "columns": [
+        "order_number",
+        "order_value"
+      ],
+      "rows": [
+        [
+          "63472",
+          "39.99"
+        ],
+        [
+          "63473",
+          "74.97"
+        ],
+        [
+          "63474",
+          "99.99"
+        ],
+        [
+          "63475",
+          "9.99"
+        ]
+      ]
+    }, {
+      "columns": [
+        "order_number",
+        "paid"
+      ],
+      "rows": [
+        [
+          "63472",
+          "true"
+        ],
+        [
+          "63473",
+          "true"
+        ],
+        [
+          "63474",
+          "false"
+        ],
+        [
+          "63475",
+          "true"
+        ]
+      ]
+    }
+  ],
+  "examples_after": [
+    {
+      "columns": [
+        "order_number",
+        "order_value",
+        "paid"
+      ],
+      "rows": [
+        [
+          "63472",
+          "39.99",
+          "true"
+        ],
+        [
+          "63473",
+          "74.97",
+          "true"
+        ],
+        [
+          "63474",
+          "99.99",
+          "false"
+        ],
+        [
+          "63475",
+          "9.99",
+          "true"
+        ]
+      ]
+    }
+  ]
+}

--- a/kuwala/core/backend/app/resources/transformation_catalog/merging/union.json
+++ b/kuwala/core/backend/app/resources/transformation_catalog/merging/union.json
@@ -1,0 +1,81 @@
+{
+  "id": "union",
+  "category": "merging",
+  "name": "Union",
+  "icon": "link",
+  "description": "With this transformation, you can merge two tables that have the same columns.",
+  "required_column_types": [],
+  "optional_column_types": ["text", "date", "numeric", "boolean"],
+  "min_number_of_input_blocks": 2,
+  "max_number_of_input_blocks": 2,
+  "macro_parameters": [
+    {
+      "id": "left_block",
+      "name": "Left block",
+      "type": "text"
+    }, {
+      "id": "right_block",
+      "name": "Right block",
+      "type": "text"
+    }
+  ],
+  "examples_before": [
+    {
+      "columns": [
+        "order_number",
+        "order_value"
+      ],
+      "rows": [
+        [
+          "63472",
+          "39.99"
+        ],
+        [
+          "63473",
+          "74.97"
+        ]
+      ]
+    }, {
+      "columns": [
+        "order_number",
+        "order_value"
+      ],
+      "rows": [
+        [
+          "23474",
+          "99.99"
+        ],
+        [
+          "23475",
+          "9.99"
+        ]
+      ]
+    }
+  ],
+  "examples_after": [
+    {
+      "columns": [
+        "order_number",
+        "order_value"
+      ],
+      "rows": [
+        [
+          "63472",
+          "39.99"
+        ],
+        [
+          "63473",
+          "74.97"
+        ],
+        [
+          "23474",
+          "99.99"
+        ],
+        [
+          "23475",
+          "9.99"
+        ]
+      ]
+    }
+  ]
+}

--- a/kuwala/core/backend/app/resources/transformation_catalog/numeric/add_columns.json
+++ b/kuwala/core/backend/app/resources/transformation_catalog/numeric/add_columns.json
@@ -1,0 +1,89 @@
+{
+  "id": "add_columns",
+  "category": "numeric",
+  "name": "Add columns",
+  "icon": "plus",
+  "description": "With this transformation, you can add the values of multiple columns and store the result in a new one.",
+  "required_column_types": ["numeric"],
+  "optional_column_types": [],
+  "min_number_of_input_blocks": 1,
+  "max_number_of_input_blocks": 1,
+  "macro_parameters": [
+    {
+      "id": "columns",
+      "name": "Columns",
+      "type": "list[text]"
+    }, {
+      "id": "result_name",
+      "name": "Result name",
+      "type": "text"
+    }
+  ],
+  "examples_before": [
+    {
+      "columns": [
+        "order_number",
+        "basket_size",
+        "shipping_cost"
+      ],
+      "rows": [
+        [
+          "63472",
+          "39.99",
+          "4.99"
+        ],
+        [
+          "63473",
+          "74.97",
+          "4.99"
+        ],
+        [
+          "63474",
+          "99.99",
+          "4.99"
+        ],
+        [
+          "63475",
+          "9.99",
+          "4.99"
+        ]
+      ]
+    }
+  ],
+  "examples_after": [
+    {
+      "columns": [
+        "order_number",
+        "basket_size",
+        "shipping_cost",
+        "amount_to_pay"
+      ],
+      "rows": [
+        [
+          "63472",
+          "39.99",
+          "4.99",
+          "44.98"
+        ],
+        [
+          "63473",
+          "74.97",
+          "4.99",
+          "79.96"
+        ],
+        [
+          "63474",
+          "99.99",
+          "4.99",
+          "104.98"
+        ],
+        [
+          "63475",
+          "9.99",
+          "4.99",
+          "14.98"
+        ]
+      ]
+    }
+  ]
+}

--- a/kuwala/core/backend/app/resources/transformation_catalog/numeric/compare_with_number.json
+++ b/kuwala/core/backend/app/resources/transformation_catalog/numeric/compare_with_number.json
@@ -1,0 +1,99 @@
+{
+  "id": "compare_with_number",
+  "category": "numeric",
+  "name": "Compare with number",
+  "icon": "greater-than-equal",
+  "description": "With this transformation, you can filter a table by comparing a numeric column with a given value.",
+  "required_column_types": ["numeric"],
+  "optional_column_types": [],
+  "min_number_of_input_blocks": 1,
+  "max_number_of_input_blocks": 1,
+  "macro_parameters": [
+    {
+      "id": "column",
+      "name": "Column",
+      "type": "text"
+    }, {
+      "id": "comparator",
+      "name": "Comparator",
+      "type": "text",
+      "options": [
+        {
+          "id": "equal",
+          "name": "="
+        }, {
+          "id": "not_equal",
+          "name": "!="
+        }, {
+          "id": "less",
+          "name": "<"
+        }, {
+          "id": "greater",
+          "name": ">"
+        }, {
+          "id": "less_or_equal",
+          "name": "<="
+        }, {
+          "id": "greater_or_equal",
+          "name": ">="
+        }
+      ]
+    }, {
+      "id": "comparison_value",
+      "name": "Comparison value",
+      "type": "numeric"
+    }
+  ],
+  "examples_before": [
+    {
+      "columns": [
+        "order_number",
+        "order_value",
+        "address_country"
+      ],
+      "rows": [
+        [
+          "63472",
+          "39.99",
+          "DE"
+        ],
+        [
+          "63473",
+          "74.97",
+          "DE"
+        ],
+        [
+          "63474",
+          "99.99",
+          "US"
+        ],
+        [
+          "63475",
+          "9.99",
+          "DE"
+        ]
+      ]
+    }
+  ],
+  "examples_after": [
+    {
+      "columns": [
+        "order_number",
+        "order_value",
+        "address_country"
+      ],
+      "rows": [
+        [
+          "63473",
+          "74.97",
+          "DE"
+        ],
+        [
+          "63474",
+          "99.99",
+          "US"
+        ]
+      ]
+    }
+  ]
+}

--- a/kuwala/core/backend/app/resources/transformation_catalog/text/contains_keyword.json
+++ b/kuwala/core/backend/app/resources/transformation_catalog/text/contains_keyword.json
@@ -1,0 +1,75 @@
+{
+  "id": "contains_keyword",
+  "category": "text",
+  "name": "Contains keyword",
+  "icon": "filter",
+  "description": "With this transformation, you can filter a table based on a column that should contain a given keyword.",
+  "required_column_types": ["text"],
+  "optional_column_types": [],
+  "min_number_of_input_blocks": 1,
+  "max_number_of_input_blocks": 1,
+  "macro_parameters": [
+    {
+      "id": "column",
+      "name": "Column",
+      "type": "text"
+    },
+    {
+      "id": "keyword",
+      "name": "Keyword",
+      "type": "text"
+    }
+  ],
+  "examples_before": [
+    {
+      "columns": [
+        "first_name",
+        "last_name",
+        "position"
+      ],
+      "rows": [
+        [
+          "John",
+          "Doe",
+          "Frontend engineer"
+        ],
+        [
+          "Laura",
+          "Santos",
+          "Backend engineer"
+        ],
+        [
+          "Marc",
+          "Johnson",
+          "Accountant"
+        ],
+        [
+          "Luisa",
+          "Jacobs",
+          "UX designer"
+        ]
+      ]
+    }
+  ],
+  "examples_after": [
+    {
+      "columns": [
+        "first_name",
+        "last_name",
+        "position"
+      ],
+      "rows": [
+        [
+          "John",
+          "Doe",
+          "Frontend engineer"
+        ],
+        [
+          "Laura",
+          "Santos",
+          "Backend engineer"
+        ]
+      ]
+    }
+  ]
+}

--- a/kuwala/core/backend/app/resources/transformation_catalog/text/filter_by_keywords.json
+++ b/kuwala/core/backend/app/resources/transformation_catalog/text/filter_by_keywords.json
@@ -1,0 +1,80 @@
+{
+  "id": "filter_by_keywords",
+  "category": "text",
+  "name": "Filter by keywords",
+  "icon": "filter",
+  "description": "With this transformation, you can filter a table based on a column that should be contained in a given set of keywords.",
+  "required_column_types": ["text"],
+  "optional_column_types": [],
+  "min_number_of_input_blocks": 1,
+  "max_number_of_input_blocks": 1,
+  "macro_parameters": [
+    {
+      "id": "column",
+      "name": "Column",
+      "type": "text"
+    },
+    {
+      "id": "keywords",
+      "name": "Keyword",
+      "type": "list[text]"
+    }
+  ],
+  "examples_before": [
+    {
+      "columns": [
+        "order_number",
+        "order_value",
+        "address_country"
+      ],
+      "rows": [
+        [
+          "63472",
+          "39.99",
+          "DE"
+        ],
+        [
+          "63473",
+          "74.97",
+          "DE"
+        ],
+        [
+          "63474",
+          "99.99",
+          "US"
+        ],
+        [
+          "63475",
+          "9.99",
+          "DE"
+        ]
+      ]
+    }
+  ],
+  "examples_after": [
+    {
+    "columns": [
+      "order_number",
+      "order_value",
+      "address_country"
+    ],
+    "rows": [
+      [
+        "63472",
+        "39.99",
+        "DE"
+      ],
+      [
+        "63473",
+        "74.97",
+        "DE"
+      ],
+      [
+        "63475",
+        "9.99",
+        "DE"
+      ]
+    ]
+  }
+  ]
+}

--- a/kuwala/core/backend/app/resources/transformation_catalog/text/filter_by_regex.json
+++ b/kuwala/core/backend/app/resources/transformation_catalog/text/filter_by_regex.json
@@ -1,0 +1,75 @@
+{
+  "id": "filter_by_regex",
+  "category": "text",
+  "name": "Filter by regex",
+  "icon": "filter",
+  "description": "With this transformation, you can filter a table based on a column that should match a given regular expression.",
+  "required_column_types": ["text"],
+  "optional_column_types": [],
+  "min_number_of_input_blocks": 1,
+  "max_number_of_input_blocks": 1,
+  "macro_parameters": [
+    {
+      "id": "column",
+      "name": "Column",
+      "type": "text"
+    },
+    {
+      "id": "regex",
+      "name": "Keyword",
+      "type": "text"
+    }
+  ],
+  "examples_before": [
+    {
+      "columns": [
+        "first_name",
+        "last_name",
+        "position"
+      ],
+      "rows": [
+        [
+          "John",
+          "Doe",
+          "Frontend engineer"
+        ],
+        [
+          "Laura",
+          "Santos",
+          "Backend engineer"
+        ],
+        [
+          "Marc",
+          "Johnson",
+          "Accountant"
+        ],
+        [
+          "Luisa",
+          "Jacobs",
+          "UX designer"
+        ]
+      ]
+    }
+  ],
+  "examples_after": [
+    {
+      "columns": [
+        "first_name",
+        "last_name",
+        "position"
+      ],
+      "rows": [
+        [
+          "John",
+          "Doe",
+          "Frontend engineer"
+        ],
+        [
+          "Laura",
+          "Santos",
+          "Backend engineer"
+        ]
+      ]
+    }
+  ]
+}

--- a/kuwala/core/backend/app/resources/transformation_catalog/time/compare_with_date.json
+++ b/kuwala/core/backend/app/resources/transformation_catalog/time/compare_with_date.json
@@ -1,0 +1,99 @@
+{
+  "id": "compare_with_date",
+  "category": "time",
+  "name": "Compare with date",
+  "icon": "greater-than-equal",
+  "description": "With this transformation, you can filter a table by comparing a date column with a given date.",
+  "required_column_types": ["date"],
+  "optional_column_types": [],
+  "min_number_of_input_blocks": 1,
+  "max_number_of_input_blocks": 1,
+  "macro_parameters": [
+    {
+      "id": "column",
+      "name": "Column",
+      "type": "text"
+    }, {
+      "id": "comparator",
+      "name": "Comparator",
+      "type": "text",
+      "options": [
+        {
+          "id": "equal",
+          "name": "="
+        }, {
+          "id": "not_equal",
+          "name": "!="
+        }, {
+          "id": "less",
+          "name": "<"
+        }, {
+          "id": "greater",
+          "name": ">"
+        }, {
+          "id": "less_or_equal",
+          "name": "<="
+        }, {
+          "id": "greater_or_equal",
+          "name": ">="
+        }
+      ]
+    }, {
+      "id": "comparison_date",
+      "name": "Comparison date",
+      "type": "date"
+    }
+  ],
+  "examples_before": [
+    {
+      "columns": [
+        "order_number",
+        "order_value",
+        "order_date"
+      ],
+      "rows": [
+        [
+          "63472",
+          "39.99",
+          "2022-02-20"
+        ],
+        [
+          "63473",
+          "74.97",
+          "2022-02-22"
+        ],
+        [
+          "63474",
+          "99.99",
+          "2022-03-09"
+        ],
+        [
+          "63475",
+          "9.99",
+          "2022-03-21"
+        ]
+      ]
+    }
+  ],
+  "examples_after": [
+    {
+      "columns": [
+        "order_number",
+        "order_value",
+        "order_date"
+      ],
+      "rows": [
+        [
+          "63474",
+          "99.99",
+          "2022-03-09"
+        ],
+        [
+          "63475",
+          "9.99",
+          "2022-03-21"
+        ]
+      ]
+    }
+  ]
+}

--- a/kuwala/core/backend/app/routers/data_block.py
+++ b/kuwala/core/backend/app/routers/data_block.py
@@ -16,7 +16,9 @@ def create_data_block(
     data_block: DataBlockCreate,
     db: Session = Depends(get_db),
 ):
-    model_name = data_block_controller.create_data_block(data_block=data_block, db=db)
+    data_block_id, model_name = data_block_controller.create_data_block(
+        data_block=data_block, db=db
+    )
     data_block = crud.create_data_block(
         db=db,
         data_block=DataBlockCreate(
@@ -27,6 +29,7 @@ def create_data_block(
             dataset_name=data_block.dataset_name,
             columns=data_block.columns,
         ),
+        generated_id=data_block_id,
         dbt_model=model_name,
     )
 

--- a/kuwala/core/backend/app/routers/data_source.py
+++ b/kuwala/core/backend/app/routers/data_source.py
@@ -1,5 +1,6 @@
 from typing import Optional
 
+import controller.data_block_controller as data_block_controller
 import controller.data_source.data_source as data_source_controller
 from database.crud.common import get_all_objects
 from database.crud.data_source import update_connection_parameters
@@ -41,7 +42,6 @@ def test_connection(
     connection_parameters: ConnectionParameters,
     db: Session = Depends(get_db),
 ):
-
     return dict(
         connected=data_source_controller.test_connection(
             data_source_id=data_source_id,
@@ -119,4 +119,11 @@ def get_table_preview(
         limit_columns=limit_columns,
         limit_rows=limit_rows,
         db=db,
+    )
+
+
+@router.put("/{data_source_id}/{schema_name}/sources/refresh")
+def refresh_sources(data_source_id: str, schema_name: str):
+    return data_block_controller.refresh_sources(
+        data_source_id=data_source_id, schema_name=schema_name
     )

--- a/kuwala/core/backend/app/routers/transformation_block.py
+++ b/kuwala/core/backend/app/routers/transformation_block.py
@@ -1,0 +1,49 @@
+import controller.transformation_block_controller as transformation_block_controller
+import database.crud.transformation_block as crud
+from database.database import get_db
+from database.schemas.transformation_block import TransformationBlockCreate
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+router = APIRouter(
+    prefix="/block/transformation",
+    tags=["transformation_block"],
+)
+
+
+@router.post("/")
+def create_transformation_block(
+    transformation_block: TransformationBlockCreate,
+    db: Session = Depends(get_db),
+):
+    (
+        data_source_id,
+        transformation_block_id,
+        model_name,
+    ) = transformation_block_controller.create_transformation_block(
+        transformation_block=transformation_block, db=db
+    )
+    transformation_block = crud.create_transformation_block(
+        db=db,
+        transformation_block=transformation_block,
+        data_source_id=data_source_id,
+        generated_id=transformation_block_id,
+        dbt_model=model_name,
+    )
+
+    return transformation_block
+
+
+@router.get("/{transformation_block_id}/preview")
+def get_data_block_preview(
+    transformation_block_id: str,
+    limit_columns: int = None,
+    limit_rows: int = None,
+    db: Session = Depends(get_db),
+):
+    return transformation_block_controller.get_transformation_block_preview(
+        transformation_block_id=transformation_block_id,
+        limit_columns=limit_columns,
+        limit_rows=limit_rows,
+        db=db,
+    )

--- a/kuwala/core/backend/app/routers/transformation_catalog.py
+++ b/kuwala/core/backend/app/routers/transformation_catalog.py
@@ -1,0 +1,56 @@
+from database.crud.common import get_all_objects
+from database.database import get_db
+import database.models.transformation_catalog as models_transformation_catalog
+import database.models.transformation_catalog_category as models_transformation_catalog_category
+import database.schemas.transformation_catalog as schemas_transformation_catalog
+import database.schemas.transformation_catalog_category as schemas_transformation_catalog_category
+from database.utils.encoder import list_props_to_json_props
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+router = APIRouter(
+    prefix="/transformation-catalog",
+    tags=["transformation_catalog"],
+)
+
+
+@router.get(
+    "/category",
+    response_model=list[
+        schemas_transformation_catalog_category.TransformationCatalogCategory
+    ],
+)
+def get_all_transformation_categories(db: Session = Depends(get_db)):
+    return get_all_objects(
+        db=db,
+        model=models_transformation_catalog_category.TransformationCatalogCategory,
+    )
+
+
+@router.get(
+    "/category/{category_id}/items",
+    response_model=list[schemas_transformation_catalog.TransformationCatalogItem],
+)
+def get_all_transformation_category_items(
+    category_id: str, db: Session = Depends(get_db)
+):
+    items = get_all_objects(
+        db=db,
+        model=models_transformation_catalog.TransformationCatalogItem,
+        where=f"category = '{category_id}'",
+    )
+    items = list(
+        map(
+            lambda item: list_props_to_json_props(
+                base_object=item,
+                list_parameters=[
+                    "examples_before",
+                    "examples_after",
+                    "macro_parameters",
+                ],
+            ),
+            items,
+        )
+    )
+
+    return items

--- a/kuwala/core/backend/requirements.txt
+++ b/kuwala/core/backend/requirements.txt
@@ -6,6 +6,7 @@ fastapi==0.74.1
 google-cloud-bigquery==2.34.1
 oyaml==1.0
 psycopg2==2.9.3
+shortuuid==1.0.8
 SQLAlchemy==1.4.31
 typing-extensions==3.10
 uvicorn[standard]==0.17.5


### PR DESCRIPTION
With this PR, I included API routes to get all categories in the transformation catalog as well as all corresponding items. 

Also, I set up the basic structure for transformation blocks and API routes to create one and preview the data in it. 

I used an initial transformation `filter_by_keyword`. 

The transformation blocks are currently limited to work only when based directly on a single data block, but the code is already structured in a way, that allows for future extendability to, for example, multiple input blocks of different types.

In the next PR I will add more transformations to the catalog that require more advanced handling in a block.