### PR TITLE
🩹 Fixed parsing of subprocess output for dbt files

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,6 +48,8 @@ services:
     profiles:
       - network
       - backend
+    volumes:
+      - ./kuwala/tmp/kuwala/backend/dbt:/opt/tmp/kuwala/backend/dbt
 
   # docker-compose --profile database up
   postgres:

--- a/kuwala/core/backend/app/controller/data_block_controller.py
+++ b/kuwala/core/backend/app/controller/data_block_controller.py
@@ -6,6 +6,10 @@ from controller.data_source.data_source import (
     get_data_source_and_data_catalog_item_id,
     get_table_preview,
 )
+from controller.utils.yaml_utils import (
+    terminal_output_to_base_model,
+    terminal_output_to_source_yaml,
+)
 import database.crud.common as crud
 from database.crud.common import generate_object_id
 import database.models.data_block as models
@@ -41,9 +45,7 @@ def create_source_yaml(dbt_dir: str, schema_name: str, update_yaml: bool = False
         shell=True,
         capture_output=True,
     )
-    source_yml = yaml.safe_load(
-        f"version: 2{output.stdout.decode('utf8').split('version: 2')[1][:-5]}"
-    )
+    source_yml = terminal_output_to_source_yaml(output=output)
 
     Path(dbt_source_model_dir).mkdir(parents=True, exist_ok=True)
 
@@ -68,9 +70,7 @@ def create_base_model(dbt_dir: str, schema_name: str, table_name: str):
         shell=True,
         capture_output=True,
     )
-    base_model = (
-        f"with source{output.stdout.decode('utf8').split('with source')[1][:-5]}"
-    )
+    base_model = terminal_output_to_base_model(output=output)
 
     with open(dbt_base_model_path, "w+") as file:
         file.write(base_model)
@@ -124,9 +124,7 @@ def create_model_yaml(dbt_dir: str, schema_name: str, table_name: str, model_nam
         shell=True,
         capture_output=True,
     )
-    source_yml = yaml.safe_load(
-        f"version: 2{output.stdout.decode('utf8').split('version: 2')[1][:-5]}"
-    )
+    source_yml = terminal_output_to_source_yaml(output=output)
 
     with open(
         f"{dbt_dir}/models/marts/{schema_name}/{table_name}/{model_name}.yml", "w+"

--- a/kuwala/core/backend/app/controller/transformation_block_controller.py
+++ b/kuwala/core/backend/app/controller/transformation_block_controller.py
@@ -7,6 +7,10 @@ from controller.data_source.data_source import (
     get_data_source_and_data_catalog_item_id,
     get_table_preview,
 )
+from controller.utils.yaml_utils import (
+    terminal_output_to_dbt_model,
+    terminal_output_to_source_yaml,
+)
 from database.crud.common import generate_object_id, get_object_by_id
 from database.database import Base, get_db
 from database.models.data_block import DataBlock
@@ -74,7 +78,7 @@ def create_model(
         capture_output=True,
     )
     dbt_model_dir = f"{dbt_dir}/models/marts/{schema_name}/{table_name}"
-    dbt_model = output.stdout.decode("utf8").split("KUWALA TRANSFORMATION")[1][:-5]
+    dbt_model = terminal_output_to_dbt_model(output=output)
     base_id = (
         base_data_block.id
         if not base_transformation_blocks or len(base_transformation_blocks)
@@ -97,9 +101,7 @@ def create_model_yaml(dbt_dir: str, dbt_model_dir: str, dbt_model_name: str):
         shell=True,
         capture_output=True,
     )
-    source_yml = yaml.safe_load(
-        f"version: 2{output.stdout.decode('utf8').split('version: 2')[1][:-5]}"
-    )
+    source_yml = terminal_output_to_source_yaml(output=output)
 
     with open(f"{dbt_model_dir}/{dbt_model_name}.yml", "w+") as file:
         yaml.safe_dump(source_yml, file, indent=4)

--- a/kuwala/core/backend/app/controller/utils/yaml_utils.py
+++ b/kuwala/core/backend/app/controller/utils/yaml_utils.py
@@ -1,0 +1,26 @@
+import oyaml as yaml
+
+
+def terminal_output_to_source_yaml(output) -> dict:
+    yaml_string = output.stdout.decode("utf8").split("version: 2")[1]
+    # Find last double quote to escape special characters at the end of the string that might be added by some IDEs
+    last_double_quote_index = yaml_string.rfind('"')
+    yaml_string = yaml_string[: last_double_quote_index + 1]
+
+    return yaml.safe_load(f"version: 2{yaml_string}")
+
+
+def terminal_output_to_base_model(output) -> str:
+    yaml_string = output.stdout.decode("utf8").split("with source")[1]
+    # Find last "renamed" to escape special characters at the end of the string that might be added by some IDEs
+    last_renamed_index = yaml_string.rfind("renamed")
+
+    return f"with source{yaml_string[:last_renamed_index]}renamed"
+
+
+def terminal_output_to_dbt_model(output) -> str:
+    return (
+        output.stdout.decode("utf8")
+        .split("-- KUWALA_TRANSFORMATION_START")[1]
+        .split("-- KUWALA_TRANSFORMATION_END")[0]
+    )

--- a/kuwala/core/backend/app/dbt/kuwala_blocks/macros/general/is_false.sql
+++ b/kuwala/core/backend/app/dbt/kuwala_blocks/macros/general/is_false.sql
@@ -2,10 +2,11 @@
     {% set rel = '{{ ref("' + dbt_model + '") }}' %}
 
     {% set query %}
-        -- KUWALA TRANSFORMATION
+        -- KUWALA_TRANSFORMATION_START
         SELECT *
         FROM {{ rel }}
         WHERE {{ column }} = False
+        -- KUWALA_TRANSFORMATION_END
     {% endset %}
 
     {% if execute %}

--- a/kuwala/core/backend/app/dbt/kuwala_blocks/macros/general/is_true.sql
+++ b/kuwala/core/backend/app/dbt/kuwala_blocks/macros/general/is_true.sql
@@ -2,10 +2,11 @@
     {% set rel = '{{ ref("' + dbt_model + '") }}' %}
 
     {% set query %}
-        -- KUWALA TRANSFORMATION
+        -- KUWALA_TRANSFORMATION_START
         SELECT *
         FROM {{ rel }}
         WHERE {{ column }} = True
+        -- KUWALA_TRANSFORMATION_END
     {% endset %}
 
     {% if execute %}

--- a/kuwala/core/backend/app/dbt/kuwala_blocks/macros/merging/join_by_id.sql
+++ b/kuwala/core/backend/app/dbt/kuwala_blocks/macros/merging/join_by_id.sql
@@ -5,9 +5,10 @@
     {% set rel_right = '{{ ref("' + dbt_model_right + '") }}' %}
 
     {% set query %}
-        -- KUWALA TRANSFORMATION
+        -- KUWALA_TRANSFORMATION_START
         SELECT *
         FROM {{ rel_left }} AS rel1 {{ join_type_value }} {{ rel_right }} AS rel2 {{ join_condition }}
+        -- KUWALA_TRANSFORMATION_END
     {% endset %}
 
     {% if execute %}

--- a/kuwala/core/backend/app/dbt/kuwala_blocks/macros/merging/union.sql
+++ b/kuwala/core/backend/app/dbt/kuwala_blocks/macros/merging/union.sql
@@ -3,10 +3,11 @@
     {% set rel_right = '{{ ref("' + dbt_model_right + '") }}' %}
 
     {% set query %}
-        -- KUWALA TRANSFORMATION
+        -- KUWALA_TRANSFORMATION_START
         SELECT * FROM {{ rel_left }}
         UNION
         SELECT * FROM {{ rel_right }}
+        -- KUWALA_TRANSFORMATION_END
     {% endset %}
 
     {% if execute %}

--- a/kuwala/core/backend/app/dbt/kuwala_blocks/macros/numeric/add_columns.sql
+++ b/kuwala/core/backend/app/dbt/kuwala_blocks/macros/numeric/add_columns.sql
@@ -6,9 +6,10 @@
     {%- endset -%}
 
     {% set query %}
-        -- KUWALA TRANSFORMATION
+        -- KUWALA_TRANSFORMATION_START
         SELECT *, {{ calculation[:-3] }} AS {{ result_name }}
         FROM {{ rel }}
+        -- KUWALA_TRANSFORMATION_END
     {% endset %}
 
     {% if execute %}

--- a/kuwala/core/backend/app/dbt/kuwala_blocks/macros/numeric/compare_with_number.sql
+++ b/kuwala/core/backend/app/dbt/kuwala_blocks/macros/numeric/compare_with_number.sql
@@ -3,10 +3,11 @@
     {% set rel = '{{ ref("' + dbt_model + '") }}' %}
 
     {% set query %}
-        -- KUWALA TRANSFORMATION
+        -- KUWALA_TRANSFORMATION_START
         SELECT *
         FROM {{ rel }}
         WHERE {{ column }} {{ comparator_value }} {{ comparison_value }}
+        -- KUWALA_TRANSFORMATION_END
     {% endset %}
 
     {% if execute %}

--- a/kuwala/core/backend/app/dbt/kuwala_blocks/macros/text/contains_keyword.sql
+++ b/kuwala/core/backend/app/dbt/kuwala_blocks/macros/text/contains_keyword.sql
@@ -2,10 +2,11 @@
     {% set rel = '{{ ref("' + dbt_model + '") }}' %}
 
     {% set query %}
-        -- KUWALA TRANSFORMATION
+        -- KUWALA_TRANSFORMATION_START
         SELECT *
         FROM {{ rel }}
         WHERE {{ column }} LIKE '%{{ decode_yaml_parameter(keyword) }}%'
+        -- KUWALA_TRANSFORMATION_END
     {% endset %}
 
     {% if execute %}

--- a/kuwala/core/backend/app/dbt/kuwala_blocks/macros/text/filter_by_keywords.sql
+++ b/kuwala/core/backend/app/dbt/kuwala_blocks/macros/text/filter_by_keywords.sql
@@ -6,10 +6,11 @@
     {%- endset -%}
 
     {% set query %}
-        -- KUWALA TRANSFORMATION
+        -- KUWALA_TRANSFORMATION_START
         SELECT *
         FROM {{ rel }}
         WHERE {{ column }} IN ({{ parsed_keywords[:-1] }})
+        -- KUWALA_TRANSFORMATION_END
     {% endset %}
 
     {% if execute %}

--- a/kuwala/core/backend/app/dbt/kuwala_blocks/macros/text/filter_by_regex.sql
+++ b/kuwala/core/backend/app/dbt/kuwala_blocks/macros/text/filter_by_regex.sql
@@ -2,7 +2,7 @@
     {% set rel = '{{ ref("' + dbt_model + '") }}' %}
 
     {% set query %}
-        -- KUWALA TRANSFORMATION
+        -- KUWALA_TRANSFORMATION_START
         SELECT *
         FROM {{ rel }}
         {% if target.type == 'bigquery' %}
@@ -10,6 +10,7 @@
         {% else %}
             WHERE {{ column }} ~ '{{ regex }}'
         {% endif %}
+        -- KUWALA_TRANSFORMATION_END
     {% endset %}
 
     {% if execute %}

--- a/kuwala/core/backend/app/dbt/kuwala_blocks/macros/time/compare_with_date.sql
+++ b/kuwala/core/backend/app/dbt/kuwala_blocks/macros/time/compare_with_date.sql
@@ -3,10 +3,11 @@
     {% set rel = '{{ ref("' + dbt_model + '") }}' %}
 
     {% set query %}
-        -- KUWALA TRANSFORMATION
+        -- KUWALA_TRANSFORMATION_START
         SELECT *
         FROM {{ rel }}
         WHERE {{ column }} {{ comparator_value }} '{{ comparison_date }}'
+        -- KUWALA_TRANSFORMATION_END
     {% endset %}
 
     {% if execute %}


### PR DESCRIPTION
When running subprocesses from an IDE (e.g., PyCharm), special characters might be added to the end of the output. However, when simply running through the terminal or Docker, those characters aren't added. Therefore I refactored the parsing of the subprocess output so all dbt files are created correctly now.

Furthermore, I've also added a volume to the backend Docker image for the dbt files.